### PR TITLE
LIBCIR-285. Updated required Node version number in README.md

### DIFF
--- a/README-MDSOAR.md
+++ b/README-MDSOAR.md
@@ -8,7 +8,7 @@ The original dspace-angular documentation is in the "README.md" file.
 
 ## Prerequisite
 
-- Node v12.x, v14.x or v16.x
+- Node v16.18.0 or later
 - npm >= v5.x
 - yarn == v1.x
 - Ensure that the MD-SOAR API is up and running by following the instructions at


### PR DESCRIPTION
DSpace 7.5 now requires Node v16.18.0 or later, so updated the README.md with that information.

https://umd-dit.atlassian.net/browse/LIBCIR-285
