### PR TITLE
LIBCIR-288. Added "Dockerfile.prod" for production Docker image

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,19 @@
+# This image will be published as dspace/dspace-angular
+# See https://github.com/DSpace/dspace-angular/tree/main/docker for usage details
+
+FROM node:18-alpine AS builder
+WORKDIR /app
+ADD . /app/
+EXPOSE 4000
+
+# Ensure Python and other build tools are available
+# These are needed to install some node modules, especially on linux/arm64
+RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*
+
+# We run yarn install with an increased network timeout (5min) to avoid "ESOCKETTIMEDOUT" errors from hub.docker.com
+# See, for example https://github.com/yarnpkg/yarn/issues/5540
+RUN yarn install --network-timeout 300000 && yarn run build:prod && rm -rf /usr/local/share/.cache/
+
+# FROM node:18-alpine
+# COPY --from=builder /usr/src/app/dist/SampleApp/ /usr/share/nginx/htm
+CMD yarn run cross-env NODE_ENV=production yarn run serve:ssr


### PR DESCRIPTION
Added "Dockerfile.prod" for generating the Docker image to use on the Kubernetes servers.

https://umd-dit.atlassian.net/browse/LIBCIR-288
