### PR TITLE
LIBCIR-290. Modified "Dockerfile.prod" to support "PM2" process manager

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -6,14 +6,17 @@ WORKDIR /app
 ADD . /app/
 EXPOSE 4000
 
+# PM2 process manager version
+ENV PM2_VERSION=5.3.0
+
 # Ensure Python and other build tools are available
 # These are needed to install some node modules, especially on linux/arm64
 RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*
 
 # We run yarn install with an increased network timeout (5min) to avoid "ESOCKETTIMEDOUT" errors from hub.docker.com
 # See, for example https://github.com/yarnpkg/yarn/issues/5540
-RUN yarn install --network-timeout 300000 && yarn run build:prod && rm -rf /usr/local/share/.cache/
+RUN yarn install --network-timeout 300000 && yarn global add pm2@$PM2_VERSION && yarn run build:prod && rm -rf /usr/local/share/.cache/
 
 # FROM node:18-alpine
 # COPY --from=builder /usr/src/app/dist/SampleApp/ /usr/share/nginx/htm
-CMD yarn run cross-env NODE_ENV=production yarn run serve:ssr
+CMD pm2 start dspace-ui.json -i max --no-daemon

--- a/README-MDSOAR.md
+++ b/README-MDSOAR.md
@@ -84,6 +84,21 @@ requests.
 
     Then go to <http://localhost:4000> in your browser
 
+## Production Docker image
+
+The Docker image used for running MD-SOAR in Kubernetes is created using the
+"Dockerfile.prod" file.
+
+This Docker image utilizes the "pm2" process manager
+(<https://pm2.keymetrics.io/>) to enable Node to scale to multiple CPUs, as
+suggested in
+<https://wiki.lyrasis.org/display/DSDOC7x/Performance+Tuning+DSpace>.
+
+The "pm2" process manager version is controlled by the "PM2_VERSION" environment
+variable in the "Dockerfile.prod" file.
+
+The "dspace-ui.json" file is used to configure the "pm2" process manager.
+
 ## Customizations
 
 ### I18n Customizations

--- a/dspace-ui.json
+++ b/dspace-ui.json
@@ -1,0 +1,14 @@
+{
+  "apps": [
+      {
+         "name": "dspace-ui",
+         "cwd": "/app",
+         "script": "dist/server/main.js",
+         "instances": "max",
+         "exec_mode": "cluster",
+         "env": {
+            "NODE_ENV": "production"
+         }
+      }
+  ]
+}


### PR DESCRIPTION
Modified the "Dockerfile.prod" used for the production Kubernetes Docker image to add the "pm2" process manager, and use "pm2" to run Angular.

Added "dspace-ui.json" file to specify the configuration parameters for "pm2".

The "--no-daemon" flag is used to start pm2, as otherwise the Docker container simply exits after starting pm2.

Explicitly set "pm2" version using the "PM2_VERSION" environment variable to ensure that an incompatible version is not accidentally introduced in the future.

https://umd-dit.atlassian.net/browse/LIBCIR-290
