### PR TITLE
LIBCIR-294. Add environment banners

### DIFF
--- a/README-MDSOAR.md
+++ b/README-MDSOAR.md
@@ -64,6 +64,13 @@ requests.
       port: 8080
       nameSpace: /server
     EOF
+
+    # UMD Environment Banner settings
+    environmentBanner:
+      text: Local Development
+      foregroundColor: "#fff"
+      backgroundColor: "#008000"
+      enabled: true
     ```
 
 3) Install the dependencies
@@ -100,6 +107,51 @@ variable in the "Dockerfile.prod" file.
 The "dspace-ui.json" file is used to configure the "pm2" process manager.
 
 ## Customizations
+
+### Environment Banner
+
+In keeping with [SSDR policy](https://confluence.umd.edu/display/LIB/Create+Environment+Banners),
+an "environment banner" will be displayed at the top of each page when running
+on non-production servers.
+
+There are two ways to configure the environment banner:
+### YAML format
+
+The following is an example of configuring in a "config/config.*.yml" YAML file,
+such as "config/config.dev.yml":
+
+```yaml
+# UMD Environment Banner settings
+environmentBanner:
+  text: Local Development
+  foregroundColor: "#fff"
+  backgroundColor: "#008000"
+  enabled: true
+```
+
+In DSpace, the configuration from the YAML files can be overridden using either
+environment variables, or a ".env" file (see the "Configuration Override"
+section in <https://wiki.lyrasis.org/display/DSDOC7x/User+Interface+Configuration>.
+
+The following environment variables can be used:
+
+- DSPACE_ENVIRONMENTBANNER_TEXT - the text to display in the banner
+- DSPACE_ENVIRONMENTBANNER_FOREGROUNDCOLOR - the foreground color for the
+  banner, as a CSS color
+- DSPACE_ENVIRONMENTBANNER_BACKGROUNDCOLOR - the background color for the
+  banner, as a CSS color
+- DSPACE_ENVIRONMENTBANNER_ENABLED - "true" (case-sensitive) enables the
+  banner. Anything else (including not being provided, or blank) disables the
+  banner.
+
+For example, in a ".env" file:
+
+```text
+DSPACE_ENVIRONMENTBANNER_TEXT=Test Environment
+DSPACE_ENVIRONMENTBANNER_FOREGROUNDCOLOR=#000
+DSPACE_ENVIRONMENTBANNER_BACKGROUNDCOLOR=#fff100
+DSPACE_ENVIRONMENTBANNER_ENABLED=true
+```
 
 ### I18n Customizations
 

--- a/README-MDSOAR.md
+++ b/README-MDSOAR.md
@@ -63,7 +63,6 @@ requests.
       host: localhost
       port: 8080
       nameSpace: /server
-    EOF
 
     # UMD Environment Banner settings
     environmentBanner:
@@ -71,6 +70,7 @@ requests.
       foregroundColor: "#fff"
       backgroundColor: "#008000"
       enabled: true
+    EOF
     ```
 
 3) Install the dependencies

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -10,6 +10,12 @@ import { ServerConfig } from './server-config.interface';
 import { mergeConfig } from './config.util';
 import { isNotEmpty } from '../app/shared/empty.util';
 
+// UMD Customization
+// Require "dotenv" package, so ".env" files in the root project directory
+// will be picked up.
+require('dotenv').config();
+// End UMD Customization
+
 const CONFIG_PATH = join(process.cwd(), 'config');
 
 type Environment = 'production' | 'development' | 'test';

--- a/src/themes/mdsoar/app/header/header.component.html
+++ b/src/themes/mdsoar/app/header/header.component.html
@@ -1,3 +1,4 @@
+<ds-umd-environment-banner></ds-umd-environment-banner>
 <header class="header">
   <nav role="navigation" [attr.aria-label]="'nav.user.description' | translate" class="container navbar navbar-expand-md px-0">
     <div class="d-flex flex-grow-1">

--- a/src/themes/mdsoar/app/umd-environment-banner/umd-environment-banner.component.html
+++ b/src/themes/mdsoar/app/umd-environment-banner/umd-environment-banner.component.html
@@ -1,0 +1,1 @@
+<div [style]="bannerStyle" *ngIf="bannerEnabled">{{ bannerText }}</div>

--- a/src/themes/mdsoar/app/umd-environment-banner/umd-environment-banner.component.spec.ts
+++ b/src/themes/mdsoar/app/umd-environment-banner/umd-environment-banner.component.spec.ts
@@ -1,0 +1,42 @@
+import { DefaultAppConfig } from '../../../../config/default-app-config';
+import { UmdEnvironmentBannerComponent } from './umd-environment-banner.component';
+
+describe('UMD Environment Banner Component', () => {
+  it('is disabled when no banner configuration is provided', () => {
+    const appConfig = new DefaultAppConfig();
+    const component = new UmdEnvironmentBannerComponent(appConfig);
+
+    expect(component.bannerText).toBe('');
+    expect(component.bannerEnabled).toBe(false);
+    expect(component.bannerStyle).toEqual({});
+  });
+
+  /* tslint:disable:no-string-literal dot-notation */
+  it('is populated when banner configuration is provided', () => {
+    const appConfig = new DefaultAppConfig();
+    appConfig['environmentBanner'] = { // eslint-disable-line @typescript-eslint/dot-notation
+      text: 'Unit Test Environment',
+      foregroundColor: '#000',
+      backgroundColor: '#fff',
+      enabled: true
+    };
+
+    const component = new UmdEnvironmentBannerComponent(appConfig);
+    component.ngOnInit();
+
+    expect(component.bannerText).toBe('Unit Test Environment');
+    expect(component.bannerEnabled).toBe(true);
+    expect(component.bannerStyle).toEqual({ 'color': '#000', 'background-color': '#fff' });
+  });
+
+  it('is disabled when enabled parameter is not "true"', () => {
+    const appConfig = new DefaultAppConfig();
+    appConfig['environmentBanner'] = {}; // eslint-disable-line @typescript-eslint/dot-notation
+
+    appConfig['environmentBanner']['enabled'] = false; // eslint-disable-line @typescript-eslint/dot-notation
+    const component = new UmdEnvironmentBannerComponent(appConfig);
+    component.ngOnInit();
+    expect(component.bannerEnabled).toBe(false);
+  });
+  /* tslint:enable:no-string-literal dot-notation */
+});

--- a/src/themes/mdsoar/app/umd-environment-banner/umd-environment-banner.component.ts
+++ b/src/themes/mdsoar/app/umd-environment-banner/umd-environment-banner.component.ts
@@ -1,0 +1,23 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { AppConfig, APP_CONFIG } from 'src/config/app-config.interface';
+@Component({
+  selector: 'ds-umd-environment-banner',
+  templateUrl: './umd-environment-banner.component.html',
+  styleUrls: ['./umd-environment-banner.component.scss']
+})
+export class UmdEnvironmentBannerComponent implements OnInit {
+  bannerText = '';
+  bannerEnabled = false;
+  bannerStyle = {};
+
+  constructor(@Inject(APP_CONFIG) private appConfig: AppConfig) {
+  }
+
+  ngOnInit(): void {
+    const bannerConfig = this.appConfig['environmentBanner']; // eslint-disable-line @typescript-eslint/dot-notation
+
+    this.bannerText = bannerConfig?.text;
+    this.bannerEnabled = bannerConfig?.enabled;
+    this.bannerStyle = { 'color': bannerConfig?.foregroundColor, 'background-color': bannerConfig?.backgroundColor };
+  }
+}

--- a/src/themes/mdsoar/eager-theme.module.ts
+++ b/src/themes/mdsoar/eager-theme.module.ts
@@ -7,6 +7,7 @@ import { RootModule } from '../../app/root.module';
 import { NavbarModule } from '../../app/navbar/navbar.module';
 import { SharedBrowseByModule } from '../../app/shared/browse-by/shared-browse-by.module';
 import { ResultsBackButtonModule } from '../../app/shared/results-back-button/results-back-button.module';
+import { UmdEnvironmentBannerComponent } from './app/umd-environment-banner/umd-environment-banner.component';
 
 /**
  * Add components that use a custom decorator to ENTRY_COMPONENTS as well as DECLARATIONS.
@@ -18,6 +19,7 @@ const DECLARATIONS = [
   ...ENTRY_COMPONENTS,
   HeaderComponent,
   NavbarComponent,
+  UmdEnvironmentBannerComponent,
 ];
 
 @NgModule({


### PR DESCRIPTION
## Environment Banner Implementation

Instead of directly porting the DRUM 6 environment configuration to DSpace 7, used the lessons learned from the "umd_lib_style" project, where it proved to be easier and more flexible to simply specify all the necessary banner parameters directly:

In a "config/config.*.yml" file:

```
environmentBanner:
text: Local Development
foregroundColor: "#fff"
backgroundColor: "#008000"
enabled: true
```

In an ".env" file, or via environment variables:

```
    DSPACE_ENVIRONMENTBANNER_TEXT
    DSPACE_ENVIRONMENTBANNER_FOREGROUNDCOLOR="#000"
    DSPACE_ENVIRONMENTBANNER_BACKGROUNDCOLOR="#d2b48c"
    DSPACE_ENVIRONMENTBANNER_ENABLED=true
```

## ".env" Loading Issue

According to the DSpace 7 documentation at

https://wiki.lyrasis.org/display/DSDOC7x/User+Interface+Configuration,

values in an ".env" file located at the project root should be used as part of the environment configuration, if such a file exists. Testing, however, was unsuccessful in getting this to work. There is a "dotenv" package (https://github.com/motdotla/dotenv) in the "package.json", but it doesn't seem to be used anywhere. The instructions for the "dotenv" package indicate that to use it there should be the line:

```
require('dotenv').config()
```

In DSpace 7.1, the above line was in "scripts/set-env.ts", but that file doesn't exist in DSpace 7.2. Placing the line at the top of the "src/config/config.server.ts" file (just below the imports), enables the ".env" file to work as indicated in the documentation.

https://umd-dit.atlassian.net/browse/LIBCIR-294