### PR TITLE
LIBCIR-282. Tweaked "University of Maryland Eastern Shore" link

### DIFF
--- a/src/themes/mdsoar/app/home-page/home-page.component.html
+++ b/src/themes/mdsoar/app/home-page/home-page.component.html
@@ -78,7 +78,7 @@
   </div>
 
   <div>
-    <a class="lead" href="/handle/11603/27642">University of Maryland, Eastern Shore</a>
+    <a class="lead" href="/handle/11603/27642">University of Maryland Eastern Shore</a>
   </div>
 
   <!-- End hard-coded Institution List -->


### PR DESCRIPTION
Removed the comma from the "University of Maryland, Eastern Shore" link, replacing it with "University of Maryland Eastern Shore" as the DSpace community does not have a comma, and the university's website does not appear to use a comma.

https://umd-dit.atlassian.net/browse/LIBCIR-282
