### PR TITLE
LIBCIR-317. Disabled DSpace 7 "End User Agreement"

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -5,6 +5,11 @@ rest:
   nameSpace: /server
 
 # UMD Customization
+
+# Disable End User Agreement
+info:
+  enableEndUserAgreement: false
+
 themes:
   # Note: When placing themes into this list, any theme that "extends" from
   # another theme MUST appear before that theme in the list.
@@ -70,4 +75,5 @@ themes:
 
   # DSpace Stock theme
   - name: 'dspace'
+
 # End UMD Customization

--- a/docs/MdsoarAngularCustomizations.md
+++ b/docs/MdsoarAngularCustomizations.md
@@ -27,3 +27,8 @@ redirect in the browser history, and enable the browser "Back" button to
 return the user to the original page.
 
 Also update tests in "src/app/core/data/dso-redirect.service.spec.ts"
+
+## Disable "End User Agreement"
+
+The "End User Agreement" is not needed, and so is disabled in the
+"config/config.yml" file.


### PR DESCRIPTION
Disabled the "End User Agreement" as this is new DSpace 7 functionality that was not present in DSpace 6, and so is likely not needed.

Updated "docs/MdsoarAngularCustomizations.md" to record the customization.

https://umd-dit.atlassian.net/browse/LIBCIR-317
