### PR TITLE
LIBCIR-319. Disabled the "privacy policy" link in GDPR popup

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -6,9 +6,12 @@ rest:
 
 # UMD Customization
 
-# Disable End User Agreement
 info:
+  # Disable End User Agreement
   enableEndUserAgreement: false
+  # Disable Privacy Policy link in GDPR popup
+  enablePrivacyStatement: false
+
 
 themes:
   # Note: When placing themes into this list, any theme that "extends" from

--- a/docs/MdsoarAngularCustomizations.md
+++ b/docs/MdsoarAngularCustomizations.md
@@ -32,3 +32,8 @@ Also update tests in "src/app/core/data/dso-redirect.service.spec.ts"
 
 The "End User Agreement" is not needed, and so is disabled in the
 "config/config.yml" file.
+
+## Disable "Privacy Policy" link in GDPR popup
+
+MD-SOAR does not have a privacy policy, so the "Privacy Policy" link in the
+GDPR popup is disabled in the "config/config.yml" file.


### PR DESCRIPTION
Disabled the "privacy policy" link in the GDPR  popup, because MD-SOAR does not currently have a privacy policy.

https://umd-dit.atlassian.net/browse/LIBCIR-319
