### PR TITLE
LIBCIR-336. Updated Simple Item sidebar with "Links to Files"

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5310,6 +5310,8 @@
 
   "item.page.department": "Department",
 
+  "item.page.description.uri": "Links to Files",
+
   "item.page.program": "Program",
 
   "item.page.rights": "Rights",

--- a/src/themes/mdsoar/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/mdsoar/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -31,6 +31,12 @@
     <!-- Files -->
     <ds-themed-item-page-file-section [item]="object"></ds-themed-item-page-file-section>
 
+    <!-- Links to Files -->
+    <ds-item-page-uri-field [item]="object"
+      [fields]="['dc.description.uri']"
+      [label]="'item.page.description.uri'">
+    </ds-item-page-uri-field>
+
     <!-- Permanent Link -->
     <ds-item-page-uri-field [item]="object"
       [fields]="['dc.identifier.uri']"


### PR DESCRIPTION
Added sidebar in the "simple item" page to show the "Links to Files" field when "dc.description.uri" metadata is available.

This was a customization that had been made in DSpace 6 (see LIBCIR-78) which was simply missed when doing the DSpace 7 customizations in LIBCIR-322).

Updated the "en.json5" file with the "Links to Files" label text.

https://umd-dit.atlassian.net/browse/LIBCIR-336
