### PR TITLE
LIBCIR-341. DSpace to MD-SOAR Label Changes

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5302,6 +5302,8 @@
 
   "browse.metadata.type.breadcrumbs": "Browse by Type",
 
+  "dso-selector.set-scope.community.button": "Search all of MD-SOAR",
+
   "home.breadcrumbs": "Maryland Shared Open Access Repository Home",
 
   "home.title": "Maryland Shared Open Access Repository Home",
@@ -5322,7 +5324,11 @@
 
   "item.page.uri": "Permanent Link",
 
+  "login.form.header": "Please log in to MD-SOAR",
+
   "menu.header.image.logo": "MD-SOAR",
+
+  "menu.section.browse_global": "All of MD-SOAR",
 
   "menu.section.browse_global_by_type": "By Type",
 
@@ -5337,6 +5343,8 @@
   "relationships.isAuthorOf.Orcid": "Author/Creator ORCID",
 
   "repository.title.prefix": "",
+
+  "search.form.scope.all": "All of MD-SOAR",
 
   "submission.import-external.back-to-my-dspace": "Back to My MD-SOAR",
 

--- a/src/themes/mdsoar/app/login-page/login-page.component.html
+++ b/src/themes/mdsoar/app/login-page/login-page.component.html
@@ -1,0 +1,10 @@
+<div class="container w-100 h-100">
+  <div class="text-center mt-5 row justify-content-center">
+    <div>
+      <img class="mb-4 login-logo" src="assets/mdsoar/images/mdsoar.png">
+      <h1 class="h3 mb-0 font-weight-normal">{{"login.form.header" | translate}}</h1>
+      <ds-log-in
+      [isStandalonePage]="true"></ds-log-in>
+    </div>
+  </div>
+</div>

--- a/src/themes/mdsoar/app/login-page/login-page.component.scss
+++ b/src/themes/mdsoar/app/login-page/login-page.component.scss
@@ -1,0 +1,4 @@
+.login-logo {
+  height: var(--ds-login-logo-height);
+  // width: var(--ds-login-logo-width);
+}

--- a/src/themes/mdsoar/app/login-page/login-page.component.ts
+++ b/src/themes/mdsoar/app/login-page/login-page.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { LoginPageComponent as BaseComponent } from '../../../../app/login-page/login-page.component';
+
+/**
+ * This component represents the login page
+ */
+@Component({
+  selector: 'ds-login-page',
+  // styleUrls: ['./login-page.component.scss'],
+  styleUrls: ['./login-page.component.scss'],
+  // templateUrl: './login-page.component.html'
+  templateUrl: './login-page.component.html'
+})
+export class LoginPageComponent extends BaseComponent {
+}

--- a/src/themes/mdsoar/lazy-theme.module.ts
+++ b/src/themes/mdsoar/lazy-theme.module.ts
@@ -14,6 +14,7 @@ import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { IdlePreloadModule } from 'angular-idle-preload';
 import { JournalEntitiesModule } from '../../app/entity-groups/journal-entities/journal-entities.module';
+import { LoginPageComponent } from './app/login-page/login-page.component';
 import { MyDspaceSearchModule } from '../../app/my-dspace-page/my-dspace-search.module';
 import { MenuModule } from '../../app/shared/menu/menu.module';
 import { NavbarModule } from '../../app/navbar/navbar.module';
@@ -53,6 +54,7 @@ import { ItemSharedModule } from '../../app/item-page/item-shared.module';
 const DECLARATIONS = [
   HomePageComponent,
   BreadcrumbsComponent,
+  LoginPageComponent,
 ];
 
 @NgModule({


### PR DESCRIPTION
Modified the “src/assets/i18n/en.json5” in the  “umd-lib/mdsoar-angular” repository adding the following keys to the end of the file to overrride the DSpace default:

* "dso-selector.set-scope.community.button": "Search all of MD-SOAR",
* "login.form.header": "Please log in to MD-SOAR",
* "menu.section.browse_global": "All of MD-SOAR",
* "search.form.scope.all": "All of MD-SOAR",

Also added the “LoginPageComponent” from the “custom” theme to the “mdsoar” theme, and then modified to override the logo image on the “Login” page that is shown if the user is being requested to login (when they click on the “Submit item to MD-SOAR” link on the home page when not logged in, for example).

https://umd-dit.atlassian.net/browse/LIBCIR-341