### PR TITLE
LIBCIR-349. Added explanatory note to CC license step on submission form

### DIFF
--- a/docs/MdsoarAngularCustomizations.md
+++ b/docs/MdsoarAngularCustomizations.md
@@ -37,3 +37,8 @@ The "End User Agreement" is not needed, and so is disabled in the
 
 MD-SOAR does not have a privacy policy, so the "Privacy Policy" link in the
 GDPR popup is disabled in the "config/config.yml" file.
+
+## Explanatory Text in "Creative Commons" License Step
+
+Added explanatory text to the "Creative Commons" license step on the submission
+form in "src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html".

--- a/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
+++ b/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
@@ -1,3 +1,28 @@
+<!-- UMD Customization -->
+<div>
+  You may add a Creative Commons License to your item. These licenses help
+  inform others how the item may or may not be used. View the
+  <a href="https://creativecommons.org/faq/" target="_blank">Creative Commons FAQ</a>
+  for more information about licensing options.
+  <br>
+  <br>
+  <ul>
+    <li>
+      <a href="https://creativecommons.org/about/cc0/" target="_blank">CC0</a> – choose this option
+      to waive all copyrights to the item (this is equivalent to placing the item into the public domain).
+    </li>
+    <li>
+      Creative Commons – choose this option to further specify if commercial
+      uses or modifications of this item are allowed.
+      (<a href="https://en.wikipedia.org/wiki/Share-alike" target="_blank">Learn more about the
+        Creative Commons “ShareAlike” model.</a>)
+    </li>
+    <li>
+      No Creative Commons License – You may skip this step if you do not wish to specify a Creative Commons license.
+    </li>
+  </ul>
+</div>
+<!-- End UMD Customization -->
 <div class="mb-4 ccLicense-select">
   <ds-select
     [disabled]="!submissionCcLicenses">


### PR DESCRIPTION
Added an explanatory note indicating:

* that the step is a optional if the user does not want to use a Creative Commons license (instead of a "No Creative Commons License" option, which is not available in the DSpace CC License step implementation)

* that the CC0 license is equivalent to a "public domain" license, since the Creative Commons API treats them the same (see https://github.com/DSpace/DSpace/issues/8543#issuecomment-1290455328)

Also added links to more information about Creative Commons licensing, and added a note on the customization to
the "docs/MdsoarAngularCustomizations.md" file.

https://umd-dit.atlassian.net/browse/LIBCIR-349
