### PR TITLE
LIBCIR-355. Added static HTML page to serve as health check endpoint

### DIFF
--- a/docs/MdsoarAngularCustomizations.md
+++ b/docs/MdsoarAngularCustomizations.md
@@ -42,3 +42,8 @@ GDPR popup is disabled in the "config/config.yml" file.
 
 Added explanatory text to the "Creative Commons" license step on the submission
 form in "src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html".
+
+## Health Check Endpoint
+
+Added static HTML page (src/themes/mdsoar/assets/static-pages/health-ping.html)
+to serve as a simple health check endpoint.

--- a/src/themes/mdsoar/assets/static-pages/health-ping.html
+++ b/src/themes/mdsoar/assets/static-pages/health-ping.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <base href="/">
+    <title>DRUM - Application Health Check</title>
+    <meta name="viewport" content="width=device-width,minimum-scale=1">
+  </head>
+
+  <body>
+    <h1>Application Health Check</h1>
+    <p>Application is OK</p>
+  </body>
+</html>


### PR DESCRIPTION
Similar to the changes made in LIBDRUM-787, added a simple static HTML page to serve as a health check for the Angular front-end.

https://umd-dit.atlassian.net/browse/LIBCIR-355

