### PR TITLE
LIBCIR-372. Changed community theme identifiers from handles to UUIDs

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -17,54 +17,75 @@ themes:
   # Note: When placing themes into this list, any theme that "extends" from
   # another theme MUST appear before that theme in the list.
 
+  # Note: In the original MD-SOAR upgrade to DSpace 7.5, themes and
+  # communities were configured using the community handles identifiers,
+  # instead of UUIDs. The switch to UUIDs was made because of a DSpace bug
+  # (<https://github.com/DSpace/DSpace/pull/9162>) in which handle identifiers
+  # were not being properly parsed. Once MD-SOAR is updated to a DSpace version
+  # containing the fix, this configuration should probably be switched back to
+  # using the community handle identifiers, as they should be more consistent
+  # over time (and across servers).
+
   # Community Themes
   - name: 'mdsoar-frostburg'
     extends: 'mdsoar'
-    handle: '11603/1'
+    # handle: '11603/1'
+    uuid: 'e34f5843-e595-4050-9f20-3c730277abf8'
 
   - name: 'mdsoar-goucher'
     extends: 'mdsoar'
-    handle: '11603/2'
+    # handle: '11603/2'
+    uuid: '600e1739-8b79-4b3a-a63e-6e294122173e'
 
   - name: 'mdsoar-hood'
     extends: 'mdsoar'
-    handle: '11603/4380'
+    # handle: '11603/4380'
+    uuid: 'ed384ea7-4a06-4491-b7ef-f81aa1abdea4'
 
   - name: 'mdsoar-loyola-notre-dame'
     extends: 'mdsoar'
-    handle: '11603/6'
+    # handle: '11603/6'
+    uuid: '6083f1c5-cab2-4a29-94aa-48136b67f4e4'
 
   - name: 'mdsoar-morgan'
     extends: 'mdsoar'
-    handle: '11603/8'
+    # handle: '11603/8
+    uuid: '2f4b286e-89fe-43d5-acd8-9b23d479e8f6'
 
   - name: 'mdsoar-salisbury'
     extends: 'mdsoar'
-    handle: '11603/9'
+    # handle: '11603/9'
+    uuid: '639afd57-c954-493d-8edd-df0a9cf4a0fd'
 
   - name: 'mdsoar-stevenson'
     extends: 'mdsoar'
-    handle: '11603/4395'
+    # handle: '11603/4395'
+    uuid: 'f2db9a4e-700c-4245-95f0-e8279a94aba7'
 
   - name: 'mdsoar-st-marys'
     extends: 'mdsoar'
-    handle: '11603/10'
+    # handle: '11603/10'
+    uuid: '641f2917-f4e7-4d07-8b84-a6191f83b4de'
 
   - name: 'mdsoar-towson'
     extends: 'mdsoar'
-    handle: '11603/11'
+    # handle: '11603/11'
+    uuid: '113328b5-9ee7-4830-990f-7dffc00104c5'
 
   - name: 'mdsoar-ubalt'
     extends: 'mdsoar'
-    handle: '11603/12'
+    # handle: '11603/12'
+    uuid: 'd0c2feef-ef35-4aac-a6a2-4824d746cda4'
 
   - name: 'mdsoar-umbc'
     extends: 'mdsoar'
-    handle: '11603/14'
+    # handle: '11603/14'
+    uuid: 'b1076c89-bcbc-455c-b2df-ec2af2d813a2'
 
   - name: 'mdsoar-umes'
     extends: 'mdsoar'
-    handle: '11603/27642'
+    # handle: '11603/27642'
+    uuid: '6e7b8e59-1247-4bfe-8ec5-66017ea52a39'
 
   # MD-SOAR Global Theme
   - name: 'mdsoar'

--- a/docs/CommunityThemes.md
+++ b/docs/CommunityThemes.md
@@ -59,16 +59,16 @@ the "mdsoar-frostburg" theme.
              ...
     ```
 
-6) Add the theme and the community handle to the "themes" section of the
-   `config/config.yml`, where \"<COMMUNITY_THEME_HANDLE>" is the community
-   handle:
+6) Add the theme and the community UUID to the "themes" section of the
+   `config/config.yml`, where \"<COMMUNITY_UUID>" is the community
+   UUID:
 
     ```text
     themes:
       ...
       - name: 'mdsoar-example'
         extends: 'mdsoar'
-        handle: '<COMMUNITY_THEME_HANDLE>'
+        uuid: '<COMMUNITY_UUID>'
     ```
 
 ### umd-lib/k8s-mdsoar Changes
@@ -76,24 +76,24 @@ the "mdsoar-frostburg" theme.
 These changes should be made in the "umd-lib/k8s-mdsoar" repository to set up
 the community theme.
 
-7) Add the theme and community handle to the `base/config/config.yml` as in Step
-   6 above, where \"<COMMUNITY_HANDLE>" is the community handle:
+7) Add the theme and community UUID to the `base/config/config.yml` as in Step
+   6 above, where \"<COMMUNITY_UUID>" is the community UUID:
 
     ```text
     themes:
       ...
       - name: 'mdsoar-example'
         extends: 'mdsoar'
-        handle: '<COMMUNITY_HANDLE>'
+        uuid: '<COMMUNITY_UUID>'
     ```
 
 ## Community Theme Required Elements
 
 When asked to create a new community theme, the following elements are required:
 
-1) The handle of the MD-SOAR community to apply the theme to.
+1) The UUID of the MD-SOAR community to apply the theme to.
 
-    Since handles are not predictable, this implies that the MD-SOAR community
+    Since UUIDs are not predictable, this implies that the MD-SOAR community
     is created prior to the rollout of the community theme.
 
 2) A logo image for the community. This file is typically a PNG file, with
@@ -104,7 +104,7 @@ When asked to create a new community theme, the following elements are required:
 
    * The institutional logo (the provided logo image)
    * The name of the institutional library
-   * The physcial address of the library
+   * The physical address of the library
    * The URL of the library website
    * A contact email
    * A contact telephone number


### PR DESCRIPTION
Modified the identifiers used to associated a community with an institutional theme from handle identifiers to UUIDs.

This is a workaround for the the stock DSpace bug described in https://github.com/DSpace/dspace-angular/issues/2348 in which handles may not be properly parsed.

The stock DSpace bug is expected to be fixed in a 7.6.x update, so simply commenting out the handles so that can be easily restored when the bug is fixed.

Updated the "CommunityThemes.md" documentation to use UUID instead of handle identifiers.

https://umd-dit.atlassian.net/browse/LIBCIR-372
