### PR TITLE
LIBCIR-407. Suppress "Researcher Profile" panel on "Update Profile"

### DIFF
--- a/src/app/profile-page/profile-page.component.html
+++ b/src/app/profile-page/profile-page.component.html
@@ -1,7 +1,15 @@
 <ng-container *ngVar="(user$ | async) as user">
   <div class="container" *ngIf="user">
     <h1>{{'profile.title' | translate}}</h1>
-    <ng-container>
+    <!-- UMD Customization -->
+    <!--
+      This change is from dspace-angular Pull Request 3585, specifically
+      commit hash "ded0079".
+      This customization marker can be remove when DRUM is update to
+      a DSpace version containing this change.
+    -->
+    <ng-container *ngIf="isResearcherProfileEnabled$ | async">
+    <!-- End UMD Customization -->
       <div class="card mb-4">
         <div class="card-header">{{'profile.card.researcher' | translate}}</div>
         <div class="card-body">

--- a/src/app/profile-page/profile-page.component.spec.ts
+++ b/src/app/profile-page/profile-page.component.spec.ts
@@ -320,7 +320,13 @@ describe('ProfilePageComponent', () => {
       });
 
       it('should return true', () => {
-        const result = component.isResearcherProfileEnabled();
+        // UMD Customization
+        // This change is from dspace-angular Pull Request 3585, specifically
+        // commit hash "ded0079".
+        // This customization marker can be remove when DRUM is update to
+        // a DSpace version containing this change.
+        const result = component.isResearcherProfileEnabled$;
+        // End UMD Customization
         const expected = cold('a', {
           a: true
         });
@@ -336,7 +342,13 @@ describe('ProfilePageComponent', () => {
       });
 
       it('should return false', () => {
-        const result = component.isResearcherProfileEnabled();
+        // UMD Customization
+        // This change is from dspace-angular Pull Request 3585, specifically
+        // commit hash "ded0079".
+        // This customization marker can be remove when DRUM is update to
+        // a DSpace version containing this change.
+        const result = component.isResearcherProfileEnabled$;
+        // End UMD Customization
         const expected = cold('a', {
           a: false
         });
@@ -352,7 +364,13 @@ describe('ProfilePageComponent', () => {
       });
 
       it('should return false', () => {
-        const result = component.isResearcherProfileEnabled();
+        // UMD Customization
+        // This change is from dspace-angular Pull Request 3585, specifically
+        // commit hash "ded0079".
+        // This customization marker can be remove when DRUM is update to
+        // a DSpace version containing this change.
+        const result = component.isResearcherProfileEnabled$;
+        // End UMD Customization
         const expected = cold('a', {
           a: false
         });

--- a/src/app/profile-page/profile-page.component.ts
+++ b/src/app/profile-page/profile-page.component.ts
@@ -192,12 +192,18 @@ export class ProfilePageComponent implements OnInit {
     this.updateProfile();
   }
 
-  /**
-   * Returns true if the researcher profile feature is enabled, false otherwise.
-   */
-  isResearcherProfileEnabled(): Observable<boolean> {
-    return this.isResearcherProfileEnabled$.asObservable();
-  }
+  // UMD Customization
+  // This change is from dspace-angular Pull Request 3585, specifically
+  // commit hash "ded0079".
+  // This customization marker can be remove when DRUM is update to
+  // a DSpace version containing this change.
+  // /**
+  //  * Returns true if the researcher profile feature is enabled, false otherwise.
+  //  */
+  // isResearcherProfileEnabled(): Observable<boolean> {
+  //   return this.isResearcherProfileEnabled$.asObservable();
+  // }
+  // End UMD Customization
 
   /**
    * Returns an error message from a password validation request with a specific reason or


### PR DESCRIPTION
This code change to suppress the "Researcher Profile" panel on the "Update Profile" page is taken from commit "ded0079" of dspace-angular pull request 3585.

Customization markers have been added to indicate that the changes came from a stock DSpace pull request, and can be removed when DRUM is upgraded to a version incorporating the changes.

These changes are the same as those made in LIBDRUM-890.

https://umd-dit.atlassian.net/browse/LIBCIR-407
