### PR TITLE
LIBCIR-393. Uncommented "/browse/*" endpoints in "robots.txt" file

### DIFF
--- a/docs/MdsoarAngularCustomizations.md
+++ b/docs/MdsoarAngularCustomizations.md
@@ -45,3 +45,8 @@ form in "src/app/submission/sections/cc-license/submission-section-cc-licenses.c
 
 Added static HTML page (src/themes/mdsoar/assets/static-pages/health-ping.html)
 to serve as a simple health check endpoint.
+
+## Uncommented "/browse/*" endpoints in "robots.txt"
+
+In the "src/robots.txt.ejs" file, uncommented the "/browse/*" endpoints, to
+dissuade crawlers from those URLs.

--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -21,7 +21,9 @@ Disallow: /entities/*?f
 
 # Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.
-# Disallow: /browse/*
+# UMD Customization
+Disallow: /browse/*
+# End UMD Customization
 #
 # If you have configured DSpace (Solr-based) Statistics to be publicly
 # accessible, then you may not want this content to be indexed


### PR DESCRIPTION
Uncommented the "/browse/*" endpoints, to dissuade crawlers from those URLs.

https://umd-dit.atlassian.net/browse/LIBCIR-393
