### PR TITLE
LIBCIR-423. Back-port of DSpace 7.6.3 "ssrBaseUrl" functionality

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -1,7 +1,7 @@
 # NOTE: will log all redux actions and transfers in console
 debug: false
 
-# Angular Universal server settings
+# Angular User Inteface settings
 # NOTE: these settings define where Node.js will start your UI application. Therefore, these
 # "ui" settings usually specify a localhost port/URL which is later proxied to a public URL (using Apache or similar)
 ui:
@@ -17,12 +17,34 @@ ui:
   # Trust X-FORWARDED-* headers from proxies (default = true)
   useProxies: true
 
+# Angular Universal / Server Side Rendering (SSR) settings
 universal:
-  # Whether to inline "critical" styles into the server-side rendered HTML.
-  # Determining which styles are critical is a relatively expensive operation;
-  # this option can be disabled to boost server performance at the expense of
-  # loading smoothness. For improved SSR performance, DSpace defaults this to false (disabled).
+  # Whether to tell Angular to inline "critical" styles into the server-side rendered HTML.
+  # Determining which styles are critical is a relatively expensive operation; this option is
+  # disabled (false) by default to boost server performance at the expense of loading smoothness.
   inlineCriticalCss: false
+  # Path prefixes to enable SSR for. By default these are limited to paths of primary DSpace objects.
+  # NOTE: The "/handle/" path ensures Handle redirects work via SSR.  The "/reload/" path ensures
+  # hard refreshes (e.g. after login) trigger SSR while fully reloading the page.
+  paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ]
+  # Whether to enable rendering of Search component on SSR.
+  # If set to true the component will be included in the HTML returned from the server side rendering.
+  # If set to false the component will not be included in the HTML returned from the server side rendering.
+  enableSearchComponent: false
+  # Whether to enable rendering of Browse component on SSR.
+  # If set to true the component will be included in the HTML returned from the server side rendering.
+  # If set to false the component will not be included in the HTML returned from the server side rendering.
+  enableBrowseComponent: false
+  # Enable state transfer from the server-side application to the client-side application.
+  # Defaults to true.
+  # Note: When using an external application cache layer, it's recommended not to transfer the state to avoid caching it.
+  # Disabling it ensures that dynamic state information is not inadvertently cached, which can improve security and
+  # ensure that users always use the most up-to-date state.
+  transferState: true
+  # When a different REST base URL is used for the server-side application, the generated state contains references to
+  # REST resources with the internal URL configured. By default, these internal URLs are replaced with public URLs.
+  # Disable this setting to avoid URL replacement during SSR. In this the state is not transferred to avoid security issues.
+  replaceRestUrl: true
 
 # The REST API server settings
 # NOTE: these settings define which (publicly available) REST API to use. They are usually
@@ -33,6 +55,9 @@ rest:
   port: 443
   # NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
   nameSpace: /server
+  # Provide a different REST url to be used during SSR execution. It must contain the whole url including protocol, server port and
+  # server namespace (uncomment to use it).
+  #ssrBaseUrl: http://localhost:8080/server
 
 # Caching settings
 cache:
@@ -82,7 +107,7 @@ cache:
     anonymousCache:
       # Maximum number of pages to cache. Default is zero (0) which means anonymous user cache is disabled.
       # As all pages are cached in server memory, increasing this value will increase memory needs.
-      # Individual cached pages are usually small (<100KB), so a value of max=1000 would only require ~100MB of memory. 
+      # Individual cached pages are usually small (<100KB), so a value of max=1000 would only require ~100MB of memory.
       max: 0
       # Amount of time after which cached pages are considered stale (in ms). After becoming stale, the cached
       # copy is automatically refreshed on the next request.
@@ -392,7 +417,30 @@ vocabularies:
     vocabulary: 'srsc'
     enabled: true
 
-# Default collection/community sorting order at Advanced search, Create/update community and collection when there are not a query. 
+# Default collection/community sorting order at Advanced search, Create/update community and collection when there are not a query.
 comcolSelectionSort:
   sortField: 'dc.title'
   sortDirection: 'ASC'
+
+# Live Region configuration
+# Live Region as defined by w3c, https://www.w3.org/TR/wai-aria-1.1/#terms:
+# Live regions are perceivable regions of a web page that are typically updated as a
+# result of an external event when user focus may be elsewhere.
+#
+# The DSpace live region is a component present at the bottom of all pages that is invisible by default, but is useful
+# for screen readers. Any message pushed to the live region will be announced by the screen reader. These messages
+# usually contain information about changes on the page that might not be in focus.
+liveRegion:
+  # The duration after which messages disappear from the live region in milliseconds
+  messageTimeOutDurationMs: 30000
+  # The visibility of the live region. Setting this to true is only useful for debugging purposes.
+  isVisible: false
+
+
+# Search settings
+search:
+  # Number used to render n UI elements called loading skeletons that act as placeholders.
+  # These elements indicate that some content will be loaded in their stead.
+  # Since we don't know how many filters will be loaded before we receive a response from the server we use this parameter for the skeletons count.
+  # e.g. If we set 5 then 5 loading skeletons will be visualized before the actual filters are retrieved.
+  defaultFiltersCount: 5

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -443,9 +443,15 @@ comcolSelectionSort:
 # End UMD Customization
 
 # Search settings
-search:
-  # Number used to render n UI elements called loading skeletons that act as placeholders.
-  # These elements indicate that some content will be loaded in their stead.
-  # Since we don't know how many filters will be loaded before we receive a response from the server we use this parameter for the skeletons count.
-  # e.g. If we set 5 then 5 loading skeletons will be visualized before the actual filters are retrieved.
-  defaultFiltersCount: 5
+# UMD Customization
+# Commenting out as part of "ssrBaseUrl" backport,
+# to ensure that unit tests pass. See LIBCIR-423
+# This customization should be removed when migrating to
+# 7.6.3 or later
+# search:
+#   # Number used to render n UI elements called loading skeletons that act as placeholders.
+#   # These elements indicate that some content will be loaded in their stead.
+#   # Since we don't know how many filters will be loaded before we receive a response from the server we use this parameter for the skeletons count.
+#   # e.g. If we set 5 then 5 loading skeletons will be visualized before the actual filters are retrieved.
+#   defaultFiltersCount: 5
+# End UMD Customization

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -430,12 +430,17 @@ comcolSelectionSort:
 # The DSpace live region is a component present at the bottom of all pages that is invisible by default, but is useful
 # for screen readers. Any message pushed to the live region will be announced by the screen reader. These messages
 # usually contain information about changes on the page that might not be in focus.
-liveRegion:
-  # The duration after which messages disappear from the live region in milliseconds
-  messageTimeOutDurationMs: 30000
-  # The visibility of the live region. Setting this to true is only useful for debugging purposes.
-  isVisible: false
-
+# UMD Customization
+# Commenting out as part of "ssrBaseUrl" backport,
+# to ensure that unit tests pass. See LIBCIR-423
+# This customization should be removed when migrating to
+# 7.6.3 or later
+# liveRegion:
+#   # The duration after which messages disappear from the live region in milliseconds
+#   messageTimeOutDurationMs: 30000
+#   # The visibility of the live region. Setting this to true is only useful for debugging purposes.
+#   isVisible: false
+# End UMD Customization
 
 # Search settings
 search:

--- a/server.ts
+++ b/server.ts
@@ -79,6 +79,9 @@ let anonymousCache: LRU<string, any>;
 // extend environment with app config for server
 extendEnvironmentWithAppConfig(environment, appConfig);
 
+// The REST server base URL
+const REST_BASE_URL = environment.rest.ssrBaseUrl || environment.rest.baseUrl;
+
 // The Express app is exported so that it can be used by serverless Functions.
 export function app() {
 
@@ -176,7 +179,7 @@ export function app() {
    * Proxy the sitemaps
    */
   router.use('/sitemap**', createProxyMiddleware({
-    target: `${environment.rest.baseUrl}/sitemaps`,
+    target: `${REST_BASE_URL}/sitemaps`,
     pathRewrite: path => path.replace(environment.ui.nameSpace, '/'),
     changeOrigin: true
   }));
@@ -185,7 +188,7 @@ export function app() {
    * Proxy the linksets
    */
   router.use('/signposting**', createProxyMiddleware({
-    target: `${environment.rest.baseUrl}`,
+    target: `${REST_BASE_URL}`,
     pathRewrite: path => path.replace(environment.ui.nameSpace, '/'),
     changeOrigin: true
   }));
@@ -269,6 +272,11 @@ function serverSideRender(req, res, sendToUser: boolean = true) {
     requestUrl: req.originalUrl,
   }, (err, data) => {
     if (hasNoValue(err) && hasValue(data)) {
+      // Replace REST URL with UI URL
+        if (environment.universal.replaceRestUrl && REST_BASE_URL !== environment.rest.baseUrl) {
+          data = data.replace(new RegExp(REST_BASE_URL, 'g'), environment.rest.baseUrl);
+      }
+
       // save server side rendered page to cache (if any are enabled)
       saveToCache(req, data);
       if (sendToUser) {
@@ -621,7 +629,7 @@ function start() {
  * The callback function to serve health check requests
  */
 function healthCheck(req, res) {
-  const baseUrl = `${environment.rest.baseUrl}${environment.actuators.endpointPath}`;
+  const baseUrl = `${REST_BASE_URL}${environment.actuators.endpointPath}`;
   axios.get(baseUrl)
     .then((response) => {
       res.status(response.status).send(response.data);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { EagerThemesModule } from '../themes/eager-themes.module';
 import { APP_CONFIG, AppConfig } from '../config/app-config.interface';
 import { StoreDevModules } from '../config/store/devtools';
 import { RootModule } from './root.module';
+import { DspaceRestInterceptor } from './core/dspace-rest/dspace-rest.interceptor';
 
 export function getConfig() {
   return environment;
@@ -101,6 +102,12 @@ const PROVIDERS = [
   {
     provide: HTTP_INTERCEPTORS,
     useClass: LogInterceptor,
+    multi: true
+  },
+  // register DspaceRestInterceptor as HttpInterceptor
+  {
+    provide: HTTP_INTERCEPTORS,
+    useClass: DspaceRestInterceptor,
     multi: true
   },
   // register the dynamic matcher used by form. MUST be provided by the app module

--- a/src/app/core/dspace-rest/dspace-rest.interceptor.spec.ts
+++ b/src/app/core/dspace-rest/dspace-rest.interceptor.spec.ts
@@ -1,0 +1,194 @@
+import {
+  HTTP_INTERCEPTORS,
+  HttpClient,
+} from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '../../../config/app-config.interface';
+import { DspaceRestInterceptor } from './dspace-rest.interceptor';
+import { DspaceRestService } from './dspace-rest.service';
+
+describe('DspaceRestInterceptor', () => {
+  let httpMock: HttpTestingController;
+  let httpClient: HttpClient;
+  const appConfig: Partial<AppConfig> = {
+    rest: {
+      ssl: false,
+      host: 'localhost',
+      port: 8080,
+      nameSpace: '/server',
+      baseUrl: 'http://api.example.com/server',
+    },
+  };
+  const appConfigWithSSR: Partial<AppConfig> = {
+    rest: {
+      ssl: false,
+      host: 'localhost',
+      port: 8080,
+      nameSpace: '/server',
+      baseUrl: 'http://api.example.com/server',
+      ssrBaseUrl: 'http://ssr.example.com/server',
+    },
+  };
+
+  describe('When SSR base URL is not set ', () => {
+    describe('and it\'s in the browser', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [HttpClientTestingModule],
+          providers: [
+            DspaceRestService,
+            {
+              provide: HTTP_INTERCEPTORS,
+              useClass: DspaceRestInterceptor,
+              multi: true,
+            },
+            { provide: APP_CONFIG, useValue: appConfig },
+            { provide: PLATFORM_ID, useValue: 'browser' },
+          ],
+        });
+
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
+      });
+
+      it('should not modify the request', () => {
+        const url = 'http://api.example.com/server/items';
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(url);
+        expect(req.request.url).toBe(url);
+        req.flush({});
+        httpMock.verify();
+      });
+    });
+
+    describe('and it\'s in SSR mode', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [HttpClientTestingModule],
+          providers: [
+            DspaceRestService,
+            {
+              provide: HTTP_INTERCEPTORS,
+              useClass: DspaceRestInterceptor,
+              multi: true,
+            },
+            { provide: APP_CONFIG, useValue: appConfig },
+            { provide: PLATFORM_ID, useValue: 'server' },
+          ],
+        });
+
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
+      });
+
+      it('should not replace the base URL', () => {
+        const url = 'http://api.example.com/server/items';
+
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(url);
+        expect(req.request.url).toBe(url);
+        req.flush({});
+        httpMock.verify();
+      });
+    });
+  });
+
+  describe('When SSR base URL is set ', () => {
+    describe('and it\'s in the browser', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [HttpClientTestingModule],
+          providers: [
+            DspaceRestService,
+            {
+              provide: HTTP_INTERCEPTORS,
+              useClass: DspaceRestInterceptor,
+              multi: true,
+            },
+            { provide: APP_CONFIG, useValue: appConfigWithSSR },
+            { provide: PLATFORM_ID, useValue: 'browser' },
+          ],
+        });
+
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
+      });
+
+      it('should not modify the request', () => {
+        const url = 'http://api.example.com/server/items';
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(url);
+        expect(req.request.url).toBe(url);
+        req.flush({});
+        httpMock.verify();
+      });
+    });
+
+    describe('and it\'s in SSR mode', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [HttpClientTestingModule],
+          providers: [
+            DspaceRestService,
+            {
+              provide: HTTP_INTERCEPTORS,
+              useClass: DspaceRestInterceptor,
+              multi: true,
+            },
+            { provide: APP_CONFIG, useValue: appConfigWithSSR },
+            { provide: PLATFORM_ID, useValue: 'server' },
+          ],
+        });
+
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
+      });
+
+      it('should replace the base URL', () => {
+        const url = 'http://api.example.com/server/items';
+        const ssrBaseUrl = appConfigWithSSR.rest.ssrBaseUrl;
+
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(ssrBaseUrl + '/items');
+        expect(req.request.url).toBe(ssrBaseUrl + '/items');
+        req.flush({});
+        httpMock.verify();
+      });
+
+      it('should not replace any query param containing the base URL', () => {
+        const url = 'http://api.example.com/server/items?url=http://api.example.com/server/item/1';
+        const ssrBaseUrl = appConfigWithSSR.rest.ssrBaseUrl;
+
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(ssrBaseUrl + '/items?url=http://api.example.com/server/item/1');
+        expect(req.request.url).toBe(ssrBaseUrl + '/items?url=http://api.example.com/server/item/1');
+        req.flush({});
+        httpMock.verify();
+      });
+    });
+  });
+});

--- a/src/app/core/dspace-rest/dspace-rest.interceptor.ts
+++ b/src/app/core/dspace-rest/dspace-rest.interceptor.ts
@@ -1,0 +1,52 @@
+import { isPlatformBrowser } from '@angular/common';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import {
+  Inject,
+  Injectable,
+  PLATFORM_ID,
+} from '@angular/core';
+import { Observable } from 'rxjs';
+
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '../../../config/app-config.interface';
+import { isEmpty } from '../../shared/empty.util';
+
+@Injectable()
+/**
+ * This Interceptor is used to use the configured base URL for the request made during SSR execution
+ */
+export class DspaceRestInterceptor implements HttpInterceptor {
+
+  /**
+   * Contains the configured application base URL
+   * @protected
+   */
+  protected baseUrl: string;
+  protected ssrBaseUrl: string;
+
+  constructor(
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
+    @Inject(PLATFORM_ID) private platformId: string,
+  ) {
+    this.baseUrl = this.appConfig.rest.baseUrl;
+    this.ssrBaseUrl = this.appConfig.rest.ssrBaseUrl;
+  }
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (isPlatformBrowser(this.platformId) || isEmpty(this.ssrBaseUrl) || this.baseUrl === this.ssrBaseUrl) {
+      return next.handle(request);
+    }
+
+    // Different SSR Base URL specified so replace it in the current request url
+    const url = request.url.replace(this.baseUrl, this.ssrBaseUrl);
+    const newRequest: HttpRequest<any> = request.clone({ url });
+    return next.handle(newRequest);
+  }
+}

--- a/src/app/core/services/server-hard-redirect.service.spec.ts
+++ b/src/app/core/services/server-hard-redirect.service.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+
+import { environment } from '../../../environments/environment.test';
 import { ServerHardRedirectService } from './server-hard-redirect.service';
 
 describe('ServerHardRedirectService', () => {
@@ -6,7 +8,7 @@ describe('ServerHardRedirectService', () => {
   const mockRequest = jasmine.createSpyObj(['get']);
   const mockResponse = jasmine.createSpyObj(['redirect', 'end']);
 
-  const service: ServerHardRedirectService = new ServerHardRedirectService(mockRequest, mockResponse);
+  let service: ServerHardRedirectService = new ServerHardRedirectService(environment, mockRequest, mockResponse);
   const origin = 'https://test-host.com:4000';
 
   beforeEach(() => {
@@ -64,6 +66,25 @@ describe('ServerHardRedirectService', () => {
 
     it('should return the location origin', () => {
       expect(service.getCurrentOrigin()).toEqual(origin);
+    });
+  });
+
+  describe('when SSR base url is set', () => {
+    const redirect = 'https://private-url:4000/server/api/bitstreams/uuid';
+    const replacedUrl = 'https://public-url/server/api/bitstreams/uuid';
+    const environmentWithSSRUrl: any = { ...environment, ...{ ...environment.rest, rest: {
+      ssrBaseUrl: 'https://private-url:4000/server',
+      baseUrl: 'https://public-url/server',
+    } } };
+    service = new ServerHardRedirectService(environmentWithSSRUrl, mockRequest, mockResponse);
+
+    beforeEach(() => {
+      service.redirect(redirect);
+    });
+
+    it('should perform a 302 redirect', () => {
+      expect(mockResponse.redirect).toHaveBeenCalledWith(302, replacedUrl);
+      expect(mockResponse.end).toHaveBeenCalled();
     });
   });
 

--- a/src/app/core/services/server-hard-redirect.service.ts
+++ b/src/app/core/services/server-hard-redirect.service.ts
@@ -2,6 +2,8 @@ import { Inject, Injectable } from '@angular/core';
 import { Request, Response } from 'express';
 import { REQUEST, RESPONSE } from '@nguniversal/express-engine/tokens';
 import { HardRedirectService } from './hard-redirect.service';
+import { APP_CONFIG, AppConfig } from '../../../config/app-config.interface';
+import { isNotEmpty } from '../../shared/empty.util';
 
 /**
  * Service for performing hard redirects within the server app module
@@ -10,6 +12,7 @@ import { HardRedirectService } from './hard-redirect.service';
 export class ServerHardRedirectService extends HardRedirectService {
 
   constructor(
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
     @Inject(REQUEST) protected req: Request,
     @Inject(RESPONSE) protected res: Response,
   ) {
@@ -25,9 +28,14 @@ export class ServerHardRedirectService extends HardRedirectService {
    *    optional HTTP status code to use for redirect (default = 302, which is a temporary redirect)
    */
   redirect(url: string, statusCode?: number) {
-
     if (url === this.req.url) {
       return;
+    }
+
+    let redirectUrl = url;
+    // If redirect url contains SSR base url then replace with public base url
+    if (isNotEmpty(this.appConfig.rest.ssrBaseUrl) && this.appConfig.rest.baseUrl !== this.appConfig.rest.ssrBaseUrl) {
+      redirectUrl = url.replace(this.appConfig.rest.ssrBaseUrl, this.appConfig.rest.baseUrl);
     }
 
     if (this.res.finished) {
@@ -35,7 +43,7 @@ export class ServerHardRedirectService extends HardRedirectService {
       req._r_count = (req._r_count || 0) + 1;
 
       console.warn('Attempted to redirect on a finished response. From',
-        this.req.url, 'to', url);
+        this.req.url, 'to', redirectUrl);
 
       if (req._r_count > 10) {
         console.error('Detected a redirection loop. killing the nodejs process');
@@ -49,9 +57,9 @@ export class ServerHardRedirectService extends HardRedirectService {
         status = 302;
       }
 
-      console.log(`Redirecting from ${this.req.url} to ${url} with ${status}`);
+      console.info(`Redirecting from ${this.req.url} to ${redirectUrl} with ${status}`);
 
-      this.res.redirect(status, url);
+      this.res.redirect(status, redirectUrl);
       this.res.end();
       // I haven't found a way to correctly stop Angular rendering.
       // So we just let it end its work, though we have already closed

--- a/src/app/shared/utils/safe-url-pipe.ts
+++ b/src/app/shared/utils/safe-url-pipe.ts
@@ -10,6 +10,6 @@ import { DomSanitizer } from '@angular/platform-browser';
 export class SafeUrlPipe implements PipeTransform {
   constructor(private domSanitizer: DomSanitizer) { }
   transform(url) {
-    return this.domSanitizer.bypassSecurityTrustResourceUrl(url);
+    return url == null ? null : this.domSanitizer.bypassSecurityTrustResourceUrl(url);
   }
 }

--- a/src/app/thumbnail/thumbnail.component.html
+++ b/src/app/thumbnail/thumbnail.component.html
@@ -1,4 +1,4 @@
-<div class="thumbnail" [class.limit-width]="limitWidth" *ngVar="(isLoading$ | async) as isLoading">
+<div class="thumbnail" [class.limit-width]="limitWidth">
   <div *ngIf="isLoading" class="thumbnail-content outer">
     <div class="inner">
       <div class="centered">
@@ -6,16 +6,14 @@
       </div>
     </div>
   </div>
-  <ng-container *ngVar="(src$ | async) as src">
-    <!-- don't use *ngIf="!isLoading" so the thumbnail can load in while the animation is playing -->
-    <img *ngIf="src !== null" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
-         [src]="src | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
-    <div *ngIf="src === null && !isLoading" class="thumbnail-content outer">
-      <div class="inner">
-        <div class="thumbnail-placeholder centered lead">
-          {{ placeholder | translate }}
-        </div>
+  <!-- don't use *ngIf="!isLoading" so the thumbnail can load in while the animation is playing -->
+  <img *ngIf="src !== null" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
+       [src]="src | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
+  <div *ngIf="src === null && !isLoading" class="thumbnail-content outer">
+    <div class="inner">
+      <div class="thumbnail-placeholder centered lead">
+        {{ placeholder | translate }}
       </div>
     </div>
-  </ng-container>
+  </div>
 </div>

--- a/src/app/thumbnail/thumbnail.component.spec.ts
+++ b/src/app/thumbnail/thumbnail.component.spec.ts
@@ -1,4 +1,4 @@
-import { DebugElement, Pipe, PipeTransform } from '@angular/core';
+import { DebugElement, Pipe, PipeTransform, PLATFORM_ID } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Bitstream } from '../core/shared/bitstream.model';
@@ -12,6 +12,9 @@ import { AuthService } from '../core/auth/auth.service';
 import { FileService } from '../core/shared/file.service';
 import { VarDirective } from '../shared/utils/var.directive';
 import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
+import { TranslateModule } from '@ngx-translate/core';
+import { ThemeService } from '../shared/theme-support/theme.service';
+import { getMockThemeService } from '../shared/mocks/theme-service.mock';
 
 // eslint-disable-next-line @angular-eslint/pipe-prefix
 @Pipe({ name: 'translate' })
@@ -31,286 +34,249 @@ describe('ThumbnailComponent', () => {
   let authService;
   let authorizationService;
   let fileService;
+  let spy;
 
-  beforeEach(waitForAsync(() => {
-    authService = jasmine.createSpyObj('AuthService', {
-      isAuthenticated: observableOf(true),
-    });
-    authorizationService = jasmine.createSpyObj('AuthorizationService', {
-      isAuthorized: observableOf(true),
-    });
-    fileService = jasmine.createSpyObj('FileService', {
+  describe('when platform is browser', () => {
+    beforeEach(waitForAsync(() => {
+      authService = jasmine.createSpyObj('AuthService', {
+        isAuthenticated: observableOf(true),
+      });
+      authorizationService = jasmine.createSpyObj('AuthorizationService', {
+        isAuthorized: observableOf(true),
+      });
+      fileService = jasmine.createSpyObj('FileService', {
       retrieveFileDownloadLink: null
-    });
-    fileService.retrieveFileDownloadLink.and.callFake((url) => observableOf(`${url}?authentication-token=fake`));
+      });
+      fileService.retrieveFileDownloadLink.and.callFake((url) => observableOf(`${url}?authentication-token=fake`));
 
-    TestBed.configureTestingModule({
+      TestBed.configureTestingModule({
       declarations: [ThumbnailComponent, SafeUrlPipe, MockTranslatePipe, VarDirective],
-      providers: [
-        { provide: AuthService, useValue: authService },
-        { provide: AuthorizationDataService, useValue: authorizationService },
-        { provide: FileService, useValue: fileService }
+        providers: [
+          { provide: AuthService, useValue: authService },
+          { provide: AuthorizationDataService, useValue: authorizationService },
+          { provide: FileService, useValue: fileService },
+          { provide: PLATFORM_ID, useValue: 'browser' },
       ]
     }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ThumbnailComponent);
-    fixture.detectChanges();
-
-    authService = TestBed.inject(AuthService);
-
-    comp = fixture.componentInstance; // ThumbnailComponent test instance
-    de = fixture.debugElement.query(By.css('div.thumbnail'));
-    el = de.nativeElement;
-  });
-
-  describe('loading', () => {
-    it('should start out with isLoading$ true', () => {
-      expect(comp.isLoading$.getValue()).toBeTrue();
-    });
-
-    it('should set isLoading$ to false once an image is successfully loaded', () => {
-      comp.setSrc('http://bit.stream');
-      fixture.debugElement.query(By.css('img.thumbnail-content')).triggerEventHandler('load', new Event('load'));
-      expect(comp.isLoading$.getValue()).toBeFalse();
-    });
-
-    it('should set isLoading$ to false once the src is set to null', () => {
-      comp.setSrc(null);
-      expect(comp.isLoading$.getValue()).toBeFalse();
-    });
-
-    it('should show a loading animation while isLoading$ is true', () => {
-      expect(de.query(By.css('ds-themed-loading'))).toBeTruthy();
-
-      comp.isLoading$.next(false);
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('ds-themed-loading'))).toBeFalsy();
-    });
-
-    describe('with a thumbnail image', () => {
-      beforeEach(() => {
-        comp.src$.next('https://bit.stream');
-        fixture.detectChanges();
-      });
-
-      it('should render but hide the image while loading and show it once done', () => {
-        let img = fixture.debugElement.query(By.css('img.thumbnail-content'));
-        expect(img).toBeTruthy();
-        expect(img.classes['d-none']).toBeTrue();
-
-        comp.isLoading$.next(false);
-        fixture.detectChanges();
-        img = fixture.debugElement.query(By.css('img.thumbnail-content'));
-        expect(img).toBeTruthy();
-        expect(img.classes['d-none']).toBeFalsy();
-      });
-
-    });
-
-    describe('without a thumbnail image', () => {
-      beforeEach(() => {
-        comp.src$.next(null);
-        fixture.detectChanges();
-      });
-
-      it('should only show the HTML placeholder once done loading', () => {
-        expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeFalsy();
-
-        comp.isLoading$.next(false);
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeTruthy();
-      });
-    });
-
-  });
-
-  const errorHandler = () => {
-    let setSrcSpy;
+    }));
 
     beforeEach(() => {
-      // disconnect error handler to be sure it's only called once
-      const img = fixture.debugElement.query(By.css('img.thumbnail-content'));
-      img.nativeNode.onerror = null;
+      fixture = TestBed.createComponent(ThumbnailComponent);
+      fixture.detectChanges();
 
-      comp.ngOnChanges({});
-      setSrcSpy = spyOn(comp, 'setSrc').and.callThrough();
+      authService = TestBed.inject(AuthService);
+
+      comp = fixture.componentInstance; // ThumbnailComponent test instance
+      de = fixture.debugElement.query(By.css('div.thumbnail'));
+      el = de.nativeElement;
     });
 
-    describe('retry with authentication token', () => {
-      it('should remember that it already retried once', () => {
-        expect(comp.retriedWithToken).toBeFalse();
-        comp.errorHandler();
-        expect(comp.retriedWithToken).toBeTrue();
+    describe('loading', () => {
+      it('should start out with isLoading$ true', () => {
+        expect(comp.isLoading).toBeTrue();
       });
 
-      describe('if not logged in', () => {
+      it('should set isLoading$ to false once an image is successfully loaded', () => {
+        comp.setSrc('http://bit.stream');
+        fixture.debugElement.query(By.css('img.thumbnail-content')).triggerEventHandler('load', new Event('load'));
+        expect(comp.isLoading).toBeFalse();
+      });
+
+      it('should set isLoading$ to false once the src is set to null', () => {
+        comp.setSrc(null);
+        expect(comp.isLoading).toBeFalse();
+      });
+
+      it('should show a loading animation while isLoading$ is true', () => {
+      expect(de.query(By.css('ds-themed-loading'))).toBeTruthy();
+
+        comp.isLoading = false;
+        fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('ds-themed-loading'))).toBeFalsy();
+      });
+
+      describe('with a thumbnail image', () => {
         beforeEach(() => {
-          authService.isAuthenticated.and.returnValue(observableOf(false));
+          comp.src = 'https://bit.stream';
+          fixture.detectChanges();
         });
 
-        it('should fall back to default', () => {
+        it('should render but hide the image while loading and show it once done', () => {
+          let img = fixture.debugElement.query(By.css('img.thumbnail-content'));
+          expect(img).toBeTruthy();
+          expect(img.classes['d-none']).toBeTrue();
+
+          comp.isLoading = false;
+          fixture.detectChanges();
+          img = fixture.debugElement.query(By.css('img.thumbnail-content'));
+          expect(img).toBeTruthy();
+          expect(img.classes['d-none']).toBeFalsy();
+        });
+
+      });
+
+      describe('without a thumbnail image', () => {
+        beforeEach(() => {
+          comp.src = null;
+          fixture.detectChanges();
+        });
+
+        it('should only show the HTML placeholder once done loading', () => {
+          expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeFalsy();
+
+          comp.isLoading = false;
+          fixture.detectChanges();
+          expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeTruthy();
+        });
+      });
+
+    });
+
+    const errorHandler = () => {
+      let setSrcSpy;
+
+      beforeEach(() => {
+        // disconnect error handler to be sure it's only called once
+        const img = fixture.debugElement.query(By.css('img.thumbnail-content'));
+        img.nativeNode.onerror = null;
+
+        comp.ngOnChanges({});
+        setSrcSpy = spyOn(comp, 'setSrc').and.callThrough();
+      });
+
+      describe('retry with authentication token', () => {
+        it('should remember that it already retried once', () => {
+          expect(comp.retriedWithToken).toBeFalse();
           comp.errorHandler();
-          expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
-        });
-      });
-
-      describe('if logged in', () => {
-        beforeEach(() => {
-          authService.isAuthenticated.and.returnValue(observableOf(true));
+          expect(comp.retriedWithToken).toBeTrue();
         });
 
-        describe('and authorized to download the thumbnail', () => {
+        describe('if not logged in', () => {
           beforeEach(() => {
-            authorizationService.isAuthorized.and.returnValue(observableOf(true));
-          });
-
-          it('should add an authentication token to the thumbnail URL', () => {
-            comp.errorHandler();
-
-            if ((comp.thumbnail as RemoteData<Bitstream>)?.hasFailed) {
-              // If we failed to retrieve the Bitstream in the first place, fall back to the default
-              expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
-            } else {
-              expect(setSrcSpy).toHaveBeenCalledWith(CONTENT + '?authentication-token=fake');
-            }
-          });
-        });
-
-        describe('but not authorized to download the thumbnail', () => {
-          beforeEach(() => {
-            authorizationService.isAuthorized.and.returnValue(observableOf(false));
+            authService.isAuthenticated.and.returnValue(observableOf(false));
           });
 
           it('should fall back to default', () => {
             comp.errorHandler();
-
             expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
-
-            // We don't need to check authorization if we failed to retrieve the Bitstreamin the first place
-            if (!(comp.thumbnail as RemoteData<Bitstream>)?.hasFailed) {
-              expect(authorizationService.isAuthorized).toHaveBeenCalled();
-            }
           });
+        });
+
+        describe('if logged in', () => {
+          beforeEach(() => {
+            authService.isAuthenticated.and.returnValue(observableOf(true));
+          });
+
+          describe('and authorized to download the thumbnail', () => {
+            beforeEach(() => {
+              authorizationService.isAuthorized.and.returnValue(observableOf(true));
+            });
+
+            it('should add an authentication token to the thumbnail URL', () => {
+              comp.errorHandler();
+
+              if ((comp.thumbnail as RemoteData<Bitstream>)?.hasFailed) {
+                // If we failed to retrieve the Bitstream in the first place, fall back to the default
+                expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
+              } else {
+                expect(setSrcSpy).toHaveBeenCalledWith(CONTENT + '?authentication-token=fake');
+              }
+            });
+          });
+
+          describe('but not authorized to download the thumbnail', () => {
+            beforeEach(() => {
+              authorizationService.isAuthorized.and.returnValue(observableOf(false));
+            });
+
+            it('should fall back to default', () => {
+              comp.errorHandler();
+
+              expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
+
+              // We don't need to check authorization if we failed to retrieve the Bitstreamin the first place
+              if (!(comp.thumbnail as RemoteData<Bitstream>)?.hasFailed) {
+                expect(authorizationService.isAuthorized).toHaveBeenCalled();
+              }
+            });
+          });
+        });
+      });
+
+      describe('after retrying with token', () => {
+        beforeEach(() => {
+          comp.retriedWithToken = true;
+        });
+
+        it('should fall back to default', () => {
+          comp.errorHandler();
+          expect(authService.isAuthenticated).not.toHaveBeenCalled();
+          expect(fileService.retrieveFileDownloadLink).not.toHaveBeenCalled();
+          expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
+        });
+      });
+    };
+
+    describe('fallback', () => {
+      describe('if there is a default image', () => {
+        it('should display the default image', () => {
+          comp.src = 'http://bit.stream';
+          comp.defaultImage = 'http://default.img';
+          comp.errorHandler();
+          expect(comp.src).toBe(comp.defaultImage);
+        });
+
+        it('should include the alt text', () => {
+          comp.src = 'http://bit.stream';
+          comp.defaultImage = 'http://default.img';
+          comp.errorHandler();
+
+          fixture.detectChanges();
+          const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
+          expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
+        });
+      });
+
+      describe('if there is no default image', () => {
+        it('should display the HTML placeholder', () => {
+          comp.src = 'http://default.img';
+          comp.defaultImage = null;
+          comp.errorHandler();
+          expect(comp.src).toBe(null);
+
+          fixture.detectChanges();
+          const placeholder = fixture.debugElement.query(By.css('div.thumbnail-placeholder')).nativeElement;
+          expect(placeholder.innerHTML).toContain('TRANSLATED ' + comp.placeholder);
         });
       });
     });
 
-    describe('after retrying with token', () => {
+    describe('with thumbnail as Bitstream', () => {
+      let thumbnail;
       beforeEach(() => {
-        comp.retriedWithToken = true;
-      });
-
-      it('should fall back to default', () => {
-        comp.errorHandler();
-        expect(authService.isAuthenticated).not.toHaveBeenCalled();
-        expect(fileService.retrieveFileDownloadLink).not.toHaveBeenCalled();
-        expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
-      });
-    });
-  };
-
-  describe('fallback', () => {
-    describe('if there is a default image', () => {
-      it('should display the default image', () => {
-        comp.src$.next('http://bit.stream');
-        comp.defaultImage = 'http://default.img';
-        comp.errorHandler();
-        expect(comp.src$.getValue()).toBe(comp.defaultImage);
-      });
-
-      it('should include the alt text', () => {
-        comp.src$.next('http://bit.stream');
-        comp.defaultImage = 'http://default.img';
-        comp.errorHandler();
-
-        fixture.detectChanges();
-        const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
-        expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
-      });
-    });
-
-    describe('if there is no default image', () => {
-      it('should display the HTML placeholder', () => {
-        comp.src$.next('http://default.img');
-        comp.defaultImage = null;
-        comp.errorHandler();
-        expect(comp.src$.getValue()).toBe(null);
-
-        fixture.detectChanges();
-        const placeholder = fixture.debugElement.query(By.css('div.thumbnail-placeholder')).nativeElement;
-        expect(placeholder.innerHTML).toContain('TRANSLATED ' + comp.placeholder);
-      });
-    });
-  });
-
-  describe('with thumbnail as Bitstream', () => {
-    let thumbnail;
-    beforeEach(() => {
-      thumbnail = new Bitstream();
-      thumbnail._links = {
-        self: { href: 'self.url' },
-        bundle: { href: 'bundle.url' },
-        format: { href: 'format.url' },
-        content: { href: CONTENT },
-        thumbnail: undefined,
-      };
-      comp.thumbnail = thumbnail;
-    });
-
-    describe('if content can be loaded', () => {
-      it('should display an image', () => {
-        comp.ngOnChanges({});
-        fixture.detectChanges();
-        const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
-        expect(image.getAttribute('src')).toBe(thumbnail._links.content.href);
-      });
-
-      it('should include the alt text', () => {
-        comp.ngOnChanges({});
-        fixture.detectChanges();
-        const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
-        expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
-      });
-    });
-
-    describe('if content can\'t be loaded', () => {
-      errorHandler();
-    });
-  });
-
-  describe('with thumbnail as RemoteData<Bitstream>', () => {
-    let thumbnail: Bitstream;
-
-    beforeEach(() => {
-      thumbnail = new Bitstream();
-      thumbnail._links = {
-        self: { href: 'self.url' },
-        bundle: { href: 'bundle.url' },
-        format: { href: 'format.url' },
-        content: { href: CONTENT },
-        thumbnail: undefined
-      };
-    });
-
-    describe('if RemoteData succeeded', () => {
-      beforeEach(() => {
-        comp.thumbnail = createSuccessfulRemoteDataObject(thumbnail);
+        thumbnail = new Bitstream();
+        thumbnail._links = {
+          self: { href: 'self.url' },
+          bundle: { href: 'bundle.url' },
+          format: { href: 'format.url' },
+          content: { href: CONTENT },
+          thumbnail: undefined,
+        };
+        comp.thumbnail = thumbnail;
       });
 
       describe('if content can be loaded', () => {
         it('should display an image', () => {
           comp.ngOnChanges({});
           fixture.detectChanges();
-          const image: HTMLElement = de.query(By.css('img')).nativeElement;
+          const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
           expect(image.getAttribute('src')).toBe(thumbnail._links.content.href);
         });
 
-        it('should display the alt text', () => {
+        it('should include the alt text', () => {
           comp.ngOnChanges({});
           fixture.detectChanges();
-          const image: HTMLElement = de.query(By.css('img')).nativeElement;
+          const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
           expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
         });
       });
@@ -320,16 +286,109 @@ describe('ThumbnailComponent', () => {
       });
     });
 
-    describe('if RemoteData failed', () => {
+    describe('with thumbnail as RemoteData<Bitstream>', () => {
+      let thumbnail: Bitstream;
+
       beforeEach(() => {
-        comp.thumbnail = createFailedRemoteDataObject();
+        thumbnail = new Bitstream();
+        thumbnail._links = {
+          self: { href: 'self.url' },
+          bundle: { href: 'bundle.url' },
+          format: { href: 'format.url' },
+          content: { href: CONTENT },
+        thumbnail: undefined
+        };
       });
 
-      it('should show the default image', () => {
-        comp.defaultImage = 'default/image.jpg';
-        comp.ngOnChanges({});
-        expect(comp.src$.getValue()).toBe('default/image.jpg');
+      describe('if RemoteData succeeded', () => {
+        beforeEach(() => {
+          comp.thumbnail = createSuccessfulRemoteDataObject(thumbnail);
+        });
+
+        describe('if content can be loaded', () => {
+          it('should display an image', () => {
+            comp.ngOnChanges({});
+            fixture.detectChanges();
+            const image: HTMLElement = de.query(By.css('img')).nativeElement;
+            expect(image.getAttribute('src')).toBe(thumbnail._links.content.href);
+          });
+
+          it('should display the alt text', () => {
+            comp.ngOnChanges({});
+            fixture.detectChanges();
+            const image: HTMLElement = de.query(By.css('img')).nativeElement;
+            expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
+          });
+        });
+
+        describe('if content can\'t be loaded', () => {
+          errorHandler();
+        });
+      });
+
+      describe('if RemoteData failed', () => {
+        beforeEach(() => {
+          comp.thumbnail = createFailedRemoteDataObject();
+        });
+
+        it('should show the default image', () => {
+          comp.defaultImage = 'default/image.jpg';
+          comp.ngOnChanges({});
+          expect(comp.src).toBe('default/image.jpg');
+        });
       });
     });
+  });
+
+  describe('when platform is server', () => {
+    beforeEach(waitForAsync(() => {
+
+      authService = jasmine.createSpyObj('AuthService', {
+        isAuthenticated: observableOf(true),
+      });
+      authorizationService = jasmine.createSpyObj('AuthorizationService', {
+        isAuthorized: observableOf(true),
+      });
+      fileService = jasmine.createSpyObj('FileService', {
+        retrieveFileDownloadLink: null,
+      });
+      fileService.retrieveFileDownloadLink.and.callFake((url) => observableOf(`${url}?authentication-token=fake`));
+
+      TestBed.configureTestingModule({
+        imports: [
+          TranslateModule.forRoot(),
+        ],
+        declarations: [ThumbnailComponent, SafeUrlPipe, MockTranslatePipe, VarDirective],
+        providers: [
+          { provide: AuthService, useValue: authService },
+          { provide: AuthorizationDataService, useValue: authorizationService },
+          { provide: FileService, useValue: fileService },
+          { provide: ThemeService, useValue: getMockThemeService() },
+          { provide: PLATFORM_ID, useValue: 'server' },
+        ],
+      }).compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ThumbnailComponent);
+      spyOn(fixture.componentInstance, 'setSrc').and.callThrough();
+      fixture.detectChanges();
+
+      authService = TestBed.inject(AuthService);
+
+      comp = fixture.componentInstance; // ThumbnailComponent test instance
+      de = fixture.debugElement.query(By.css('div.thumbnail'));
+      el = de.nativeElement;
+    });
+
+    it('should start out with isLoading$ true', () => {
+      expect(comp.isLoading).toBeTrue();
+      expect(de.query(By.css('ds-themed-loading'))).toBeTruthy();
+    });
+
+    it('should not call setSrc', () => {
+      expect(comp.setSrc).not.toHaveBeenCalled();
+    });
+
   });
 });

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, Input, OnChanges, PLATFORM_ID, SimpleChanges } from 
 import { Bitstream } from '../core/shared/bitstream.model';
 import { hasNoValue, hasValue } from '../shared/empty.util';
 import { RemoteData } from '../core/data/remote-data';
-import { BehaviorSubject, of as observableOf } from 'rxjs';
+import { of as observableOf } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { FeatureID } from '../core/data/feature-authorization/feature-id';
 import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
@@ -35,7 +35,7 @@ export class ThumbnailComponent implements OnChanges {
   /**
    * The src attribute used in the template to render the image.
    */
-  src$ = new BehaviorSubject<string>(undefined);
+  src: string = undefined;
 
   retriedWithToken = false;
 
@@ -58,7 +58,7 @@ export class ThumbnailComponent implements OnChanges {
    * Whether the thumbnail is currently loading
    * Start out as true to avoid flashing the alt text while a thumbnail is being loaded.
    */
-  isLoading$ = new BehaviorSubject(true);
+  isLoading = true;
 
   constructor(
     @Inject(PLATFORM_ID) private platformID: any,
@@ -114,7 +114,7 @@ export class ThumbnailComponent implements OnChanges {
    * Otherwise, fall back to the default image or a HTML placeholder
    */
   errorHandler() {
-    const src = this.src$.getValue();
+    const src = this.src;
     const thumbnail = this.bitstream;
     const thumbnailSrc = thumbnail?._links?.content?.href;
 
@@ -166,9 +166,9 @@ export class ThumbnailComponent implements OnChanges {
    * @param src
    */
   setSrc(src: string): void {
-    this.src$.next(src);
+    this.src = src;
     if (src === null) {
-      this.isLoading$.next(false);
+      this.isLoading = false;
     }
   }
 
@@ -176,6 +176,6 @@ export class ThumbnailComponent implements OnChanges {
    * Stop the loading animation once the thumbnail is successfully loaded
    */
   successHandler() {
-    this.isLoading$.next(false);
+    this.isLoading = false;
   }
 }

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Inject, Input, OnChanges, PLATFORM_ID, SimpleChanges } from '@angular/core';
 import { Bitstream } from '../core/shared/bitstream.model';
 import { hasNoValue, hasValue } from '../shared/empty.util';
 import { RemoteData } from '../core/data/remote-data';
@@ -8,6 +8,7 @@ import { FeatureID } from '../core/data/feature-authorization/feature-id';
 import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
 import { AuthService } from '../core/auth/auth.service';
 import { FileService } from '../core/shared/file.service';
+import { isPlatformBrowser } from '@angular/common';
 
 /**
  * This component renders a given Bitstream as a thumbnail.
@@ -60,6 +61,7 @@ export class ThumbnailComponent implements OnChanges {
   isLoading$ = new BehaviorSubject(true);
 
   constructor(
+    @Inject(PLATFORM_ID) private platformID: any,
     protected auth: AuthService,
     protected authorizationService: AuthorizationDataService,
     protected fileService: FileService,
@@ -71,16 +73,18 @@ export class ThumbnailComponent implements OnChanges {
    * Use a default image if no actual image is available.
    */
   ngOnChanges(changes: SimpleChanges): void {
-    if (hasNoValue(this.thumbnail)) {
-      this.setSrc(this.defaultImage);
-      return;
-    }
+    if (isPlatformBrowser(this.platformID)) {
+      if (hasNoValue(this.thumbnail)) {
+        this.setSrc(this.defaultImage);
+        return;
+      }
 
-    const src = this.contentHref;
-    if (hasValue(src)) {
-      this.setSrc(src);
-    } else {
-      this.setSrc(this.defaultImage);
+      const src = this.contentHref;
+      if (hasValue(src)) {
+        this.setSrc(src);
+      } else {
+        this.setSrc(this.defaultImage);
+      }
     }
   }
 

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -233,6 +233,7 @@ export const buildAppConfig = (destConfigPath?: string): AppConfig => {
   appConfig.rest.port = isNotEmpty(ENV('REST_PORT', true)) ? getNumberFromString(ENV('REST_PORT', true)) : appConfig.rest.port;
   appConfig.rest.nameSpace = isNotEmpty(ENV('REST_NAMESPACE', true)) ? ENV('REST_NAMESPACE', true) : appConfig.rest.nameSpace;
   appConfig.rest.ssl = isNotEmpty(ENV('REST_SSL', true)) ? getBooleanFromString(ENV('REST_SSL', true)) : appConfig.rest.ssl;
+  appConfig.rest.ssrBaseUrl = isNotEmpty(ENV('REST_SSRBASEURL', true)) ? ENV('REST_SSRBASEURL', true) : appConfig.rest.ssrBaseUrl;
 
   // apply build defined production
   appConfig.production = env === 'production';

--- a/src/config/server-config.interface.ts
+++ b/src/config/server-config.interface.ts
@@ -6,4 +6,8 @@ export class ServerConfig implements Config {
   public port: number;
   public nameSpace: string;
   public baseUrl?: string;
+  public ssrBaseUrl?: string;
+  // This boolean will be automatically set on server startup based on whether "baseUrl" and "ssrBaseUrl"
+  // have different values.
+  public hasSsrBaseUrl?: boolean;
 }

--- a/src/config/universal-config.interface.ts
+++ b/src/config/universal-config.interface.ts
@@ -13,4 +13,36 @@ export interface UniversalConfig extends Config {
    * loading smoothness.
    */
   inlineCriticalCss?: boolean;
+
+  /**
+   * Enable state transfer from the server-side application to the client-side application.
+   * Defaults to true.
+   *
+   * Note: When using an external application cache layer, it's recommended not to transfer the state to avoid caching it.
+   * Disabling it ensures that dynamic state information is not inadvertently cached, which can improve security and
+   * ensure that users always use the most up-to-date state.
+   */
+  transferState: boolean;
+
+  /**
+   * When a different REST base URL is used for the server-side application, the generated state contains references to
+   * REST resources with the internal URL configured. By default, these internal URLs are replaced with public URLs.
+   * Disable this setting to avoid URL replacement during SSR. In this the state is not transferred to avoid security issues.
+   */
+  replaceRestUrl: boolean;
+
+  /**
+   * Paths to enable SSR for. Defaults to the home page and paths in the sitemap.
+   */
+  paths: Array<string>;
+
+  /**
+   * Whether to enable rendering of search component on SSR
+   */
+  enableSearchComponent: boolean;
+
+  /**
+   * Whether to enable rendering of browse component on SSR
+   */
+  enableBrowseComponent: boolean;
 }

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -9,5 +9,10 @@ export const environment: Partial<BuildConfig> = {
     async: true,
     time: false,
     inlineCriticalCss: false,
-  }
+    transferState: true,
+    replaceRestUrl: true,
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ],
+    enableSearchComponent: false,
+    enableBrowseComponent: false,
+  },
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -12,6 +12,11 @@ export const environment: BuildConfig = {
     async: true,
     time: false,
     inlineCriticalCss: false,
+    transferState: true,
+    replaceRestUrl: false,
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ],
+    enableSearchComponent: false,
+    enableBrowseComponent: false,
   },
 
   // Angular Universal server settings.
@@ -314,5 +319,14 @@ export const environment: BuildConfig = {
       vocabulary: 'srsc',
       enabled: true
     }
-  ]
+  ],
+
+  liveRegion: {
+    messageTimeOutDurationMs: 30000,
+    isVisible: false,
+  },
+
+  search: {
+    filterPlaceholdersCount: 5
+  }
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -332,7 +332,14 @@ export const environment: BuildConfig = {
   // },
   // End UMD Customization
 
-  search: {
-    filterPlaceholdersCount: 5
-  }
+  // UMD Customization
+  // Commenting out as part of "ssrBaseUrl" backport,
+  // to ensure that unit tests pass. See LIBCIR-423
+  // This customization should be removed when migrating to
+  // 7.6.3 or later
+  // search: {
+  //   filterPlaceholdersCount: 5
+  // }
+  // End UMD Customization
+
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -321,10 +321,16 @@ export const environment: BuildConfig = {
     }
   ],
 
-  liveRegion: {
-    messageTimeOutDurationMs: 30000,
-    isVisible: false,
-  },
+  // UMD Customization
+  // Commenting out as part of "ssrBaseUrl" backport,
+  // to ensure that unit tests pass. See LIBCIR-423
+  // This customization should be removed when migrating to
+  // 7.6.3 or later
+  // liveRegion: {
+  //   messageTimeOutDurationMs: 30000,
+  //   isVisible: false,
+  // },
+  // End UMD Customization
 
   search: {
     filterPlaceholdersCount: 5

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,7 +14,12 @@ export const environment: Partial<BuildConfig> = {
     async: true,
     time: false,
     inlineCriticalCss: false,
-  }
+    transferState: true,
+    replaceRestUrl: false,
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ],
+    enableSearchComponent: false,
+    enableBrowseComponent: false,
+  },
 };
 
 /*

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -30,9 +30,12 @@ import { filter, find, map } from 'rxjs/operators';
 import { isNotEmpty } from '../../app/shared/empty.util';
 import { logStartupMessage } from '../../../startup-message';
 import { MenuService } from '../../app/shared/menu/menu.service';
+import { RequestService } from '../../app/core/data/request.service';
 import { RootDataService } from '../../app/core/data/root-data.service';
-import { firstValueFrom, Subscription } from 'rxjs';
+import { firstValueFrom, lastValueFrom, Subscription } from 'rxjs';
 import { ServerCheckGuard } from '../../app/core/server-check/server-check.guard';
+import { HALEndpointService } from '../../app/core/shared/hal-endpoint.service';
+import { BuildConfig } from '../../config/build-config.interface';
 
 /**
  * Performs client-side initialization.
@@ -46,7 +49,7 @@ export class BrowserInitService extends InitService {
     protected store: Store<AppState>,
     protected correlationIdService: CorrelationIdService,
     protected transferState: TransferState,
-    @Inject(APP_CONFIG) protected appConfig: AppConfig,
+    @Inject(APP_CONFIG) protected appConfig: BuildConfig,
     protected translate: TranslateService,
     protected localeService: LocaleService,
     protected angulartics2DSpace: Angulartics2DSpace,
@@ -59,6 +62,8 @@ export class BrowserInitService extends InitService {
     protected menuService: MenuService,
     private rootDataService: RootDataService,
     protected serverCheckGuard: ServerCheckGuard,
+    private requestService: RequestService,
+    private halService: HALEndpointService,
   ) {
     super(
       store,
@@ -117,13 +122,20 @@ export class BrowserInitService extends InitService {
    * @private
    */
   private async loadAppState(): Promise<boolean> {
-    const state = this.transferState.get<any>(InitService.NGRX_STATE, null);
-    this.transferState.remove(InitService.NGRX_STATE);
-    this.store.dispatch(new StoreAction(StoreActionTypes.REHYDRATE, state));
-    return this.store.select(coreSelector).pipe(
-      find((core: any) => isNotEmpty(core)),
-      map(() => true)
-    ).toPromise();
+    // The app state can be transferred only when SSR and CSR are using the same base url for the REST API
+    if (this.appConfig.universal.transferState) {
+      const state = this.transferState.get<any>(InitService.NGRX_STATE, null);
+      this.transferState.remove(InitService.NGRX_STATE);
+      this.store.dispatch(new StoreAction(StoreActionTypes.REHYDRATE, state));
+      return lastValueFrom(
+        this.store.select(coreSelector).pipe(
+          find((core: any) => isNotEmpty(core)),
+          map(() => true),
+        ),
+      );
+    } else {
+      return Promise.resolve(true);
+    }
   }
 
   private trackAuthTokenExpiration(): void {
@@ -145,17 +157,15 @@ export class BrowserInitService extends InitService {
   }
 
   /**
-   * During an external authentication flow invalidate the SSR transferState
+   * During an external authentication flow invalidate the
    * data in the cache. This allows the app to fetch fresh content.
    * @private
    */
   private externalAuthCheck() {
-
     this.sub = this.authService.isExternalAuthentication().pipe(
         filter((externalAuth: boolean) => externalAuth)
       ).subscribe(() => {
-        // Clear the transferState data.
-        this.rootDataService.invalidateRootCache();
+        this.requestService.setStaleByHrefSubstring(this.halService.getRootHref());
         this.authService.setExternalAuthStatus(false);
       }
     );


### PR DESCRIPTION
Back-port of "ssrBaseUrl" functionality from
DSpace-angular pull request 3962

Implements the ability for Angular Universal to
communicate directly with the MD-SOAR back-end
pod, instead of going through the ingress.

This change was needed for the AWS migration.

https://umd-dit.atlassian.net/browse/LIBCIR-423
