### PR TITLE
LIBCIR-443. Modify "tests" GitHub Action to enable test to succeed.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,9 @@ jobs:
       COMPOSE_PROJECT_NAME: 'ci'
       # Docker Registry to use for Docker compose scripts below.
       # We use GitHub's Container Registry to avoid aggressive rate limits at DockerHub.
-      DOCKER_REGISTRY: ghcr.io
+      # UMD Customization
+      #DOCKER_REGISTRY: ghcr.io
+      # End UMD Customization
     strategy:
       # Create a matrix of Node versions to test against (in parallel)
       matrix:
@@ -119,12 +121,14 @@ jobs:
           retention-days: 14
 
       # Login to our Docker registry, so that we can access private Docker images using "docker compose" below.
-      - name: Login to ${{ env.DOCKER_REGISTRY }}
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # UMD Customization
+      # - name: Login to ${{ env.DOCKER_REGISTRY }}
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ${{ env.DOCKER_REGISTRY }}
+      #     username: ${{ github.repository_owner }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+      # End UMD Customization
 
       # Using "docker compose" start backend using CI configuration
       # and load assetstore from a cached copy
@@ -204,36 +208,38 @@ jobs:
       - name: Shutdown Docker containers
         run: docker compose -f ./docker/docker-compose-ci.yml down
 
-  # Codecov upload is a separate job in order to allow us to restart this separate from the entire build/test
-  # job above. This is necessary because Codecov uploads seem to randomly fail at times.
-  # See https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
-  codecov:
-    # Must run after 'tests' job above
-    needs: tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  # UMD Customization
+  # # Codecov upload is a separate job in order to allow us to restart this separate from the entire build/test
+  # # job above. This is necessary because Codecov uploads seem to randomly fail at times.
+  # # See https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
+  # codecov:
+  #   # Must run after 'tests' job above
+  #   needs: tests
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
 
-      # Download artifacts from previous 'tests' job
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+  #     # Download artifacts from previous 'tests' job
+  #     - name: Download coverage artifacts
+  #       uses: actions/download-artifact@v4
 
-      # Now attempt upload to Codecov using its action.
-      # NOTE: We use a retry action to retry the Codecov upload if it fails the first time.
-      #
-      # Retry action: https://github.com/marketplace/actions/retry-action
-      # Codecov action: https://github.com/codecov/codecov-action
-      - name: Upload coverage to Codecov.io
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          action: codecov/codecov-action@v4
-          # Ensure codecov-action throws an error when it fails to upload
-          # This allows us to auto-restart the action if an error is thrown
-          with: |
-            fail_ci_if_error: true
-            token: ${{ secrets.CODECOV_TOKEN }}
-          # Try re-running action 5 times max
-          attempt_limit: 5
-          # Run again in 30 seconds
-          attempt_delay: 30000
+  #     # Now attempt upload to Codecov using its action.
+  #     # NOTE: We use a retry action to retry the Codecov upload if it fails the first time.
+  #     #
+  #     # Retry action: https://github.com/marketplace/actions/retry-action
+  #     # Codecov action: https://github.com/codecov/codecov-action
+  #     - name: Upload coverage to Codecov.io
+  #       uses: Wandalen/wretry.action@v1.3.0
+  #       with:
+  #         action: codecov/codecov-action@v4
+  #         # Ensure codecov-action throws an error when it fails to upload
+  #         # This allows us to auto-restart the action if an error is thrown
+  #         with: |
+  #           fail_ci_if_error: true
+  #           token: ${{ secrets.CODECOV_TOKEN }}
+  #         # Try re-running action 5 times max
+  #         attempt_limit: 5
+  #         # Run again in 30 seconds
+  #         attempt_delay: 30000
+  # End UMD Customization

--- a/cypress/e2e/end-user-agreement.cy.ts
+++ b/cypress/e2e/end-user-agreement.cy.ts
@@ -1,7 +1,9 @@
 import { testA11y } from 'cypress/support/utils';
 
+// UMD Customization
+// End User Agreement is suppressed in the UMD configuration
 describe('End User Agreement', () => {
-  it('should pass accessibility tests', () => {
+  it.skip('should pass accessibility tests', () => {
     cy.visit('/info/end-user-agreement');
 
     // Page must first be visible
@@ -11,3 +13,4 @@ describe('End User Agreement', () => {
     testA11y('ds-end-user-agreement');
   });
 });
+// End UMD Customization

--- a/cypress/e2e/privacy.cy.ts
+++ b/cypress/e2e/privacy.cy.ts
@@ -1,7 +1,9 @@
 import { testA11y } from 'cypress/support/utils';
 
+// UMD Customization
+// Privacy Policy is suppressed in the UMD configuration
 describe('Privacy', () => {
-  it('should pass accessibility tests', () => {
+  it.skip('should pass accessibility tests', () => {
     cy.visit('/info/privacy');
 
     // Page must first be visible
@@ -11,3 +13,4 @@ describe('Privacy', () => {
     testA11y('ds-privacy');
   });
 });
+// End UMD Customization

--- a/docs/MdsoarAngularCustomizations.md
+++ b/docs/MdsoarAngularCustomizations.md
@@ -50,3 +50,19 @@ to serve as a simple health check endpoint.
 
 In the "src/robots.txt.ejs" file, uncommented the "/browse/*" endpoints, to
 dissuade crawlers from those URLs.
+
+## Modified GitHub Workflow Actions
+
+Modified the following in ".github/workflows/build.yml" so that the GitHub jobs
+would successfully complete:
+
+* Commented out the "DOCKER_REGISTRY" environment variable and
+  "Login to ${{ env.DOCKER_REGISTRY }}" step, because it was causing Docker
+  image pulls to fail when running the
+  "Start DSpace REST Backend via Docker (for e2e tests)" step.
+
+* Modified the "Verify SSR" step for check for "Maryland" in the title instead
+  of "DSpace"
+
+* Commented out the "codecov" job, because UMD does not have an appropriate key
+  for uploading the results to codecov.io.


### PR DESCRIPTION
In DSpace 8.1, "build.yml" was changed to pull Docker images from “ghcr.io” Docker registry, which requires access credentials.

Since UMD does not access to these credentials, the “tests” GitHub Action fails.

Followed the DRUM (LIBDRUM-957) changes to , restore the “tests” GitHub Action by commenting out the use of the “ghcr.io” Docker registry and associated credentials.

Also commented out the "codecov" task, as UMD does not have the credentials to run it (see LIBDRUM-892).

Update "docs/MdsoarAngularCustomizations.md" to record the change.

Also disabled the following “end-to-end” tests:

* “cypress/e2e/end-user-agreement.cy.ts” - MD-SOAR does not display the “End User Agreement” (see LIBCIR-317)
* “cypress/e2e/privacy.cy.ts” - MD-SOAR does not display a privacy policy (see LIBCIR-319).

https://umd-dit.atlassian.net/browse/LIBCIR-443
