### PR TITLE
LIBCIR-450. Make "Subcommunities and Collections" default tab

### DIFF
--- a/docs/MdsoarAngularCustomizations.md
+++ b/docs/MdsoarAngularCustomizations.md
@@ -8,6 +8,25 @@ Angular code, to customize it for MD-SOAR.
 This document is intended to cover specific changes made to Angular behavior
 that are outside of "normal" DSpace customization.
 
+## "Browse" Bar on Community Pages
+
+Modified the "Browse" bar on the community pages so that the
+"Subcommunities and Collections" tab is selected by default, instead of the
+"Search" tab.
+
+This required modifying the routing in the following files:
+
+* src/app/community-page/community-page-routes.ts
+* src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.ts
+
+by removing the "subcoms-cols" URL subpath associated with the
+"SubComColSectionComponent", and adding a "search" URL subpath for the
+"ComcolSearchSectionComponent".
+
+Note: This is a BREAKING CHANGE for users that have bookmarks pointing to a
+search results page, as the search results page is now under the "search"
+subpath.
+
 ## Disable "End User Agreement"
 
 The "End User Agreement" is not needed, and so is disabled in the

--- a/src/app/community-page/community-page-routes.ts
+++ b/src/app/community-page/community-page-routes.ts
@@ -73,13 +73,12 @@ export const ROUTES: Route[] = [
           menu: dsoEditMenuResolver,
         },
         children: [
+          // UMD Customization
+          // Make "Subcommunities and Collections" tab the default tab
+          // when there is no subpath for the URL
+          // "Search" tab displayed when URL has "search" subpath
           {
             path: '',
-            pathMatch: 'full',
-            component: ComcolSearchSectionComponent,
-          },
-          {
-            path: 'subcoms-cols',
             pathMatch: 'full',
             component: SubComColSectionComponent,
             resolve: {
@@ -87,6 +86,12 @@ export const ROUTES: Route[] = [
             },
             data: { breadcrumbKey: 'community.subcoms-cols' },
           },
+          {
+            path: 'search',
+            pathMatch: 'full',
+            component: ComcolSearchSectionComponent,
+          },
+          // End UMD Customization
           {
             path: 'browse/:id',
             pathMatch: 'full',

--- a/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.ts
+++ b/src/app/shared/comcol/comcol-page-browse-by/comcol-page-browse-by.component.ts
@@ -103,16 +103,23 @@ export class ComcolPageBrowseByComponent implements OnDestroy, OnInit {
             });
           } else if (this.contentType === 'community') {
             comColRoute = getCommunityPageRoute(this.id);
+            // UMD Customization
+            // "Subcommunities and Colllections" tab is default tab (selected)
+            // when there is no subpath for the URL
+            // "Search" tab displayed as selected when URL has "search" subpath
+            // Note: "allOptions" order affects the order of display, so Search
+            // is first
             allOptions.push({
               id: 'search',
               label: 'collection.page.browse.search.head',
-              routerLink: comColRoute,
+              routerLink: `${comColRoute}/search`,
             });
             allOptions.push({
               id: 'comcols',
               label: 'community.all-lists.head',
-              routerLink: `${comColRoute}/subcoms-cols`,
+              routerLink: comColRoute,
             });
+            // End UMD Customization
           }
 
           allOptions.push(...browseDefListRD.payload.page.map((config: BrowseDefinition) => ({


### PR DESCRIPTION
Modified the "Browse" bar on the communities pages so that the "Subcommunities and Collections" tab is selected by default, instead of the "Search" tab.

This required modifying the routing, replacing the "subcoms-cols" subpath that pointed to the "SubComColSectionComponent" with the empty subpath, and adding a new subpath, "search" for pointing to the "ComcolSearchSectionComponent".

Note: This would be a BREAKING CHANGE for anyone who had an MD-SOAR search results page in their bookmarks – they would now get the “Subcommunities and Collections” page (with the
“Subcommunities and Collections” tab highlighted), without any search results.

https://umd-dit.atlassian.net/browse/LIBCIR-450
