### PR TITLE
LIBCIR-451. Update Author/Contributor/Advisor hint text via I18n

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6846,6 +6846,12 @@
 
   "search.form.scope.all": "All of MD-SOAR",
 
+  "submission.hint.dc.contributor": "Enter the name(s) of any other contributors to the item (e.g. editors, illustrators, narrators, etc.) in the <strong>Last Name, First Name</strong> format (e.g Smith, John). To add multiple contributors, enter one name at a time and then click \"Add more\".",
+
+  "submission.hint.dc.contributor.advisor": "If applicable, enter the name(s) of the advisor(s) who oversaw the creation of this item in the <strong>Last Name, First Name</strong> format (e.g Smith, John). To add multiple advisors, enter one name at a time and then click \"Add more\".",
+
+  "submission.hint.dc.contributor.author": "Enter the name(s) of the author(s) of this item in the <strong>Last Name, First Name</strong> format (e.g Smith, John). To add multiple authors, enter one name at a time and then click \"Add more\".",
+
   "submission.import-external.back-to-my-dspace": "Back to My MD-SOAR",
 
   // End UMD Customization


### PR DESCRIPTION
The MD-SOAR Community Admins have requested changes to the "hints" for the "Author(s)", "Contributor(s)", and "Advisor(s)" fields on the submission form to make more prominent that the names should be in "Last Name, First Name" format. The requested changes include using **bold** text in the hint.

In the DSpace back-end, any HTML tags added directly to the hint text in the “dspace/config/submission-forms.xml” file are displayed AS-IS in GUI, instead of being interpreted by the browser. To enable HTML tags to be included in the hints, replaced the hard-coded text in the DSpace back-end with I18n keys.

Added the I18n keys and updated text to the “src/assets/i18n/en.json5” file for display on the submission form.

https://umd-dit.atlassian.net/browse/LIBCIR-451
