### PR TITLE
LIBCIR-478. Added component for displaying MD-SOAR Accessibiity info

### DIFF
--- a/docs/MdsoarAngularCustomizations.md
+++ b/docs/MdsoarAngularCustomizations.md
@@ -51,6 +51,15 @@ form in "src/app/submission/sections/cc-license/submission-section-cc-licenses.c
 Added static HTML page (src/themes/mdsoar/assets/static-pages/health-ping.html)
 to serve as a simple health check endpoint.
 
+## MD-SOAR Accessibility Information page
+
+Added an "MD-SOAR Accessibility Information" page at the
+"/info/mdsoar-accessibility" endpoint providing detailed information about the
+accessibility of the MD-SOAR platform.
+
+In the navigation bar menu, added an "Accessibility" link to the page (placed
+after the "Browse By" dropdown)
+
 ## Uncommented "/browse/*" endpoints in "robots.txt"
 
 In the "src/robots.txt.ejs" file, uncommented the "/browse/*" endpoints, to

--- a/src/app/info/info-routes.ts
+++ b/src/app/info/info-routes.ts
@@ -2,7 +2,10 @@ import {
   Route,
   Routes,
 } from '@angular/router';
+// UMD Customization
+import { UmdAccessibilityComponent } from 'src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility.component';
 
+// End UMD Customization
 import { environment } from '../../environments/environment';
 import { i18nBreadcrumbResolver } from '../core/breadcrumbs/i18n-breadcrumb.resolver';
 import { notifyInfoGuard } from '../core/coar-notify/notify-info/notify-info.guard';
@@ -17,6 +20,7 @@ import {
   END_USER_AGREEMENT_PATH,
   FEEDBACK_PATH,
   PRIVACY_PATH,
+  UMD_ACCESSIBILITY_PATH, // UMD Customization
 } from './info-routing-paths';
 import { NotifyInfoComponent } from './notify-info/notify-info.component';
 import { ThemedPrivacyComponent } from './privacy/themed-privacy.component';
@@ -36,6 +40,14 @@ export const ROUTES: Routes = [
     resolve: { breadcrumb: i18nBreadcrumbResolver },
     data: { title: 'info.accessibility-settings.title', breadcrumbKey: 'info.accessibility-settings' },
   },
+  // UMD Customization
+  {
+    path: UMD_ACCESSIBILITY_PATH,
+    component: UmdAccessibilityComponent,
+    resolve: { breadcrumb: i18nBreadcrumbResolver },
+    data: { title: 'info.umd-accessibility.title', breadcrumbKey: 'info.umd-accessibility' },
+  },
+  // End UMD Customization
   environment.info.enableEndUserAgreement ? {
     path: END_USER_AGREEMENT_PATH,
     component: ThemedEndUserAgreementComponent,

--- a/src/app/info/info-routing-paths.ts
+++ b/src/app/info/info-routing-paths.ts
@@ -5,6 +5,9 @@ export const PRIVACY_PATH = 'privacy';
 export const FEEDBACK_PATH = 'feedback';
 export const COAR_NOTIFY_SUPPORT = 'coar-notify-support';
 export const ACCESSIBILITY_SETTINGS_PATH = 'accessibility';
+// UMD Customization
+export const UMD_ACCESSIBILITY_PATH = 'mdsoar-accessibility';
+// End UMD Customization
 
 export function getEndUserAgreementPath() {
   return getSubPath(END_USER_AGREEMENT_PATH);
@@ -24,6 +27,10 @@ export function getCOARNotifySupportPath(): string {
 
 export function getAccessibilitySettingsPath() {
   return getSubPath(ACCESSIBILITY_SETTINGS_PATH);
+}
+
+export function getUmdAccessibilityPath() {
+  return getSubPath(UMD_ACCESSIBILITY_PATH);
 }
 
 function getSubPath(path: string) {

--- a/src/app/menu-resolver.service.ts
+++ b/src/app/menu-resolver.service.ts
@@ -110,6 +110,20 @@ export class MenuResolverService  {
           link: `/community-list`,
         } as LinkMenuItemModel,
       },
+      // UMD Customization
+      // UMD Accessibility Link
+      {
+        id: `umd-accessibility`,
+        active: false,
+        visible: true,
+        index: 2, // Place after "Browse By"
+        model: {
+          type: MenuItemType.LINK,
+          text: `menu.section.umd-accessibility`,
+          link: `/info/mdsoar-accessibility`,
+        } as LinkMenuItemModel,
+      },
+      // End UMD Customization
     ];
     // Read the different Browse-By types from config and add them to the browse menu
     this.browseService.getBrowseDefinitions()

--- a/src/app/menu-resolver.service.ts
+++ b/src/app/menu-resolver.service.ts
@@ -34,6 +34,9 @@ import { RemoteData } from './core/data/remote-data';
 import { BrowseDefinition } from './core/shared/browse-definition.model';
 import { ConfigurationProperty } from './core/shared/configuration-property.model';
 import { getFirstCompletedRemoteData } from './core/shared/operators';
+// UMD Customization
+import { getUmdAccessibilityPath } from './info/info-routing-paths';
+// End UMD Customization
 import { ThemedCreateCollectionParentSelectorComponent } from './shared/dso-selector/modal-wrappers/create-collection-parent-selector/themed-create-collection-parent-selector.component';
 import { ThemedCreateCommunityParentSelectorComponent } from './shared/dso-selector/modal-wrappers/create-community-parent-selector/themed-create-community-parent-selector.component';
 import { ThemedCreateItemParentSelectorComponent } from './shared/dso-selector/modal-wrappers/create-item-parent-selector/themed-create-item-parent-selector.component';
@@ -120,7 +123,7 @@ export class MenuResolverService  {
         model: {
           type: MenuItemType.LINK,
           text: `menu.section.umd-accessibility`,
-          link: `/info/mdsoar-accessibility`,
+          link: getUmdAccessibilityPath(),
         } as LinkMenuItemModel,
       },
       // End UMD Customization

--- a/src/app/menu.resolver.spec.ts
+++ b/src/app/menu.resolver.spec.ts
@@ -154,6 +154,14 @@ describe('menuResolver', () => {
           id: 'browse_global', visible: true,
         }));
       });
+
+      // UMD Customization
+      it('should include a UMD accessibility link', () => {
+        expect(menuService.addSection).toHaveBeenCalledWith(MenuID.PUBLIC, jasmine.objectContaining({
+          id: 'umd-accessibility', visible: true,
+        }));
+      });
+      // End UMD Customization
     });
   });
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6891,6 +6891,12 @@
 
   "home.title": "Maryland Shared Open Access Repository Home",
 
+  "info.umd-accessibility.breadcrumbs": "MD-SOAR Accessibility Information",
+
+  "info.umd-accessibility.head": "MD-SOAR Accessibility Information",
+
+  "info.umd-accessibility.title": "MD-SOAR Accessibility Information",
+
   "item.page.citation": "Citation of Original Publication",
 
   "item.page.department": "Department",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6921,6 +6921,8 @@
 
   "menu.section.browse_global_by_type": "By Type",
 
+  "menu.section.umd-accessibility": "Accessibility",
+
   "mydspace.breadcrumbs": "My MD-SOAR",
 
   "mydspace.title": "My MD-SOAR",

--- a/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility-content/umd-accessibility-content.component.html
+++ b/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility-content/umd-accessibility-content.component.html
@@ -48,7 +48,7 @@
   <li>
     WCAG 2.x, Level AA
     <ul>
-      1.2.3 Audio description (prerecorded)
+      <li>1.2.3 Audio description (prerecorded)</li>
     </ul>
   </li>
 </ul>

--- a/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility-content/umd-accessibility-content.component.html
+++ b/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility-content/umd-accessibility-content.component.html
@@ -1,0 +1,176 @@
+<h1>
+  {{ 'info.umd-accessibility.head' | translate }}
+</h1>
+
+<p>
+  This page provides detailed information about the accessibility of the MD-SOAR
+  platform. While efforts are being made to achieve full Title II compliance, we
+  appreciate the adverse impacts that non-accessible platforms and content have
+  on users. Please refer to this site for information about the state of our
+  platform and records.
+</p>
+
+<h2>
+  Platform accessibility
+</h2>
+
+<p>
+  MD-SOAR uses <a href="https://dspace.org">DSpace software</a> as its
+  underlying infrastructure. Information about the accessibility of DSpace can
+  be found on the
+  <a href="https://dspace.org/accessibility/">vendor-supplied Accessibility
+    page</a>.
+  Here, you will find the vendor accessibility statement, a brief overview
+  of their accessibility testing methodology, and links to their most recent
+  VPATs. Furthermore, USMAI documentation of platform accessibility is available
+  on the
+  <a
+    href="https://usmai.org/portal/spaces/SYSTEMS/pages/377323599/MD-SOAR+accessibility+documentation">
+    MD-SOAR system accessibility page on the USMAI Portal</a>.
+</p>
+
+<p>
+  Per the latest DSpace VPAT - dated November 17, 2025 - DSpace largely conforms
+  to WCAG 2.1 AA standards. While there are a few notable factors that are not
+  fully supported, the VPAT indicates that there are development tickets that
+  aim to address these issues. These issues include:
+</p>
+
+<ul>
+  <li>
+    WCAG 2.x, Level A
+    <ul>
+      <li>1.1.1 Non-text Content</li>
+      <li>1.2.1 Audio-only and Video-only (prerecorded)</li>
+      <li>1.2.3 Audio description or media alternative (prerecorded)</li>
+    </ul>
+  </li>
+  <li>
+    WCAG 2.x, Level AA
+    <ul>
+      1.2.3 Audio description (prerecorded)
+    </ul>
+  </li>
+</ul>
+
+<p>
+  We acknowledge that these outstanding compliance issues may cause difficulty
+  for some users to access content on MD-SOAR. However, we are confident that
+  efforts by the DSpace developers will lead to a timely solution to these
+  issues.
+</p>
+
+<h2>
+  Content accessibility
+</h2>
+
+<p>
+  Content on MD-SOAR, sometimes referred to as bitstreams, includes a variety of
+  formats, including conventional word documents such as PDFs, Word documents,
+  and TXT files, research data, audiovisual materials, digitized archival
+  documents, and more. While we appreciate that providing accessible formats for
+  every document is the expectation for Title II compliance, remediating our
+  legacy content - consisting of over 30,000 individual records - is not
+  achievable given our currently available resources. While we are happy to
+  provide on-demand remediation services for individual records (see
+  <a [routerLink]="'.'" fragment="requesting-record-remediation">
+    Requesting record remediation
+  </a>
+  for more information), we are currently working to identify a manageable
+  workflow for remediating our legacy content. More information on this effort
+  will be made available in the future.
+</p>
+
+<p>
+  Please note that the materials held on MD-SOAR are maintained for reference,
+  research, and record-keeping purposes only. Use of these materials in
+  classroom settings or for instructional purposes may require material
+  remediation in order to remain compliant with Title II requirements.
+</p>
+
+<h2>
+  Roadmap for addressing accessibility issues
+</h2>
+
+<p>
+  As we continue our efforts towards full compliance with Title II regulations,
+  we have created the following roadmap to lead our efforts.
+</p>
+
+<h3>
+  Short term
+</h3>
+
+<ul>
+  <li>
+    Add accessibility page to MD-SOAR detailing our current known accessibility
+    issues and a roadmap towards compliance
+  </li>
+  <li>
+    Add a hyperlink to global site footer that links to the accessibility page
+    and
+    a direct link to remediation request instructions
+  </li>
+  <li>
+    Add metadata to all MD-SOAR records that indicate their archival and
+    research
+    purpose
+  </li>
+  <li>
+    Add a pop-up message for new submissions that alert record submitters to the
+    expectation of accessible content on MD-SOAR
+  </li>
+</ul>
+
+<h3>
+  Medium term
+</h3>
+
+<ul>
+  <li>
+    Continued monitoring of DSpace development on known accessibility issues
+  </li>
+  <li>
+    Regular review of accessibility monitoring for MD-SOAR via SiteImprove in
+    order to identify and address global accessibility issues
+  </li>
+  <li>
+    Continued monitoring of available accessibility and remediation tools in
+    order to identify a sustainable, cost-effective methodology for remediating
+    legacy content and integrated remediation of new submissions
+  </li>
+</ul>
+
+<h2 id="requesting-record-remediation">
+  Requesting record remediation
+</h2>
+
+<p>
+  If you require remediation of a specific MD-SOAR record, please email
+  <a href="mailto:mdsoar-help@umd.edu">mdsoar-help&#64;umd.edu</a>.
+</p>
+
+<p>
+  In your message, please include the following details:
+</p>
+
+<ul>
+  <li>
+    A link to the record such as the URL (e.g.
+    https://mdsoar.org/items/12345678-1234-5678-842e-12345678901234567) or the
+    record's permanent link (e.g. http://hdl.handle.net/11603/12345)
+  </li>
+  <li>
+    A brief description of the accommodation that is required (i.e. an accessible
+    PDF format, audio transcription, etc.)
+  </li>
+</ul>
+
+<p>
+  After receipt of this request, a message will be sent to the responsible
+  institution alerting them to the remediation request. Once available, an
+  accessible copy of the record in question will be forwarded to the requestor
+  and the accessible copy will be added to the publicly-available MD-SOAR
+  record. Please note that due to the varying capacity of our institutions, we
+  cannot provide a concrete timeline for responses to remediation requests.
+</p>

--- a/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility-content/umd-accessibility-content.component.spec.ts
+++ b/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility-content/umd-accessibility-content.component.spec.ts
@@ -1,0 +1,34 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { ActivatedRouteStub } from 'src/app/shared/testing/active-router.stub';
+
+import { UmdAccessibilityContentComponent } from './umd-accessibility-content.component';
+
+describe('UmdAccessibilityContentComponent', () => {
+  let component: UmdAccessibilityContentComponent;
+  let fixture: ComponentFixture<UmdAccessibilityContentComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), UmdAccessibilityContentComponent],
+      providers: [{ provide: ActivatedRoute, useValue: new ActivatedRouteStub() }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UmdAccessibilityContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility-content/umd-accessibility-content.component.ts
+++ b/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility-content/umd-accessibility-content.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'ds-umd-accessibility-content',
+  templateUrl: './umd-accessibility-content.component.html',
+  styleUrls: ['./umd-accessibility-content.component.scss'],
+  standalone: true,
+  imports: [RouterLink, TranslateModule],
+})
+/**
+ * Component displaying the contents of the UMD Accessibility information
+ */
+export class UmdAccessibilityContentComponent {
+}

--- a/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility.component.html
+++ b/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility.component.html
@@ -1,0 +1,3 @@
+<div class="container">
+  <ds-umd-accessibility-content></ds-umd-accessibility-content>
+</div>

--- a/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility.component.spec.ts
+++ b/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility.component.spec.ts
@@ -1,0 +1,36 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { ActivatedRouteStub } from 'src/app/shared/testing/active-router.stub';
+
+import { UmdAccessibilityComponent } from './umd-accessibility.component';
+
+describe('UmdAccessibilityComponent', () => {
+  let component: UmdAccessibilityComponent;
+  let fixture: ComponentFixture<UmdAccessibilityComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot(), UmdAccessibilityComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UmdAccessibilityComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility.component.ts
+++ b/src/themes/mdsoar/app/info/umd-accessibility/umd-accessibility.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+import { UmdAccessibilityContentComponent } from './umd-accessibility-content/umd-accessibility-content.component';
+
+@Component({
+  selector: 'ds-umd-accessibility',
+  templateUrl: './umd-accessibility.component.html',
+  styleUrls: ['./umd-accessibility.component.scss'],
+  standalone: true,
+  imports: [UmdAccessibilityContentComponent],
+})
+/**
+ * Component displaying the UMD Accessibility information
+ */
+export class UmdAccessibilityComponent {
+}

--- a/src/themes/mdsoar/eager-theme.module.ts
+++ b/src/themes/mdsoar/eager-theme.module.ts
@@ -5,7 +5,6 @@ import { FooterComponent } from './app/footer/footer.component';
 import { HeaderComponent } from './app/header/header.component';
 import { HomeNewsComponent } from './app/home-page/home-news/home-news.component';
 import { HomePageComponent } from './app/home-page/home-page.component';
-import { UmdAccessibilityComponent } from './app/info/umd-accessibility/umd-accessibility.component';
 import { UntypedItemComponent } from './app/item-page/simple/item-types/untyped-item/untyped-item.component';
 import { NavbarComponent } from './app/navbar/navbar.component';
 import { UmdEnvironmentBannerComponent } from './app/umd-environment-banner/umd-environment-banner.component';
@@ -26,7 +25,6 @@ const DECLARATIONS = [
   HeaderComponent,
   NavbarComponent,
   FooterComponent,
-  UmdAccessibilityComponent,
   UmdEnvironmentBannerComponent,
 ];
 

--- a/src/themes/mdsoar/eager-theme.module.ts
+++ b/src/themes/mdsoar/eager-theme.module.ts
@@ -5,6 +5,7 @@ import { FooterComponent } from './app/footer/footer.component';
 import { HeaderComponent } from './app/header/header.component';
 import { HomeNewsComponent } from './app/home-page/home-news/home-news.component';
 import { HomePageComponent } from './app/home-page/home-page.component';
+import { UmdAccessibilityComponent } from './app/info/umd-accessibility/umd-accessibility.component';
 import { UntypedItemComponent } from './app/item-page/simple/item-types/untyped-item/untyped-item.component';
 import { NavbarComponent } from './app/navbar/navbar.component';
 import { UmdEnvironmentBannerComponent } from './app/umd-environment-banner/umd-environment-banner.component';
@@ -25,6 +26,7 @@ const DECLARATIONS = [
   HeaderComponent,
   NavbarComponent,
   FooterComponent,
+  UmdAccessibilityComponent,
   UmdEnvironmentBannerComponent,
 ];
 


### PR DESCRIPTION
Added a "UmdAccessibilityComponent" (and related component, "UmdAccessibilityContentComponent"), modeled after the stock DSpace "PrivacyComponent (and "PrivacyContentComponent").

This page seemed to best fit within the "info" section of MD-SOAR, so modified the "info-routes.ts" and "info-routing-paths.ts", so that the page would be available at the "/info/mdsoar-accessibility" path.

Note: The stock DSpace already has an "/info/accessibility" endpoint, which is used for managing accessibility settings.

Text for the page was from https://docs.google.com/document/d/1DNrMGF3AI1EGSinB16tn_ytVLI5OUBxLq23OKxUo5-U (last modified on Mar 31, 2026)

https://umd-dit.atlassian.net/browse/LIBCIR-478
