### PR TITLE
LIBCIR-479. Added accessibility information to institutional footers

### DIFF
--- a/docs/MdsoarAngularCustomizations.md
+++ b/docs/MdsoarAngularCustomizations.md
@@ -58,7 +58,13 @@ Added an "MD-SOAR Accessibility Information" page at the
 accessibility of the MD-SOAR platform.
 
 In the navigation bar menu, added an "Accessibility" link to the page (placed
-after the "Browse By" dropdown)
+after the "Browse By" dropdown).
+
+## MD-SOAR Accessibility Footer
+
+Added an "umd-footer-accessibility" component to be a common source of
+accessibility information that is displayed in each of the institutional
+footers, with links to the MD-SOAR Accessibility information page.
 
 ## Uncommented "/browse/*" endpoints in "robots.txt"
 

--- a/src/themes/mdsoar-bowie-state/app/footer/footer.component.html
+++ b/src/themes/mdsoar-bowie-state/app/footer/footer.component.html
@@ -18,10 +18,7 @@
                                     Phone: <a href="tel:3018603627">301-860-3627</a>
     </p>
     <hr>
-    <p>
-                                    If you wish to submit a copyright complaint or withdrawal request, please email
-                                    <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&amp;body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-                                </p>
+    <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
     </div>
     </div>
     </div>

--- a/src/themes/mdsoar-bowie-state/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-bowie-state/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-frostburg/app/footer/footer.component.html
+++ b/src/themes/mdsoar-frostburg/app/footer/footer.component.html
@@ -18,10 +18,7 @@
                                     Phone: <a href="tel:3016874889">301-687-4889</a>
     </p>
     <hr>
-    <p>
-                                    If you wish to submit a copyright complaint or withdrawal request, please email
-                                    <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&amp;body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-                                </p>
+    <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
     </div>
     </div>
     </div>

--- a/src/themes/mdsoar-frostburg/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-frostburg/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-goucher/app/footer/footer.component.html
+++ b/src/themes/mdsoar-goucher/app/footer/footer.component.html
@@ -18,10 +18,7 @@
     <a href="https://libraryguides.goucher.edu/c.php?g=1393713&amp;p=10311623">eScholarship&#64;Goucher</a>
     </p>
     <hr>
-    <p>
-                                    If you wish to submit a copyright complaint or withdrawal request, please email
-                                    <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&amp;body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-                                </p>
+    <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
     </div>
     </div>
     </div>

--- a/src/themes/mdsoar-goucher/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-goucher/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-hood/app/footer/footer.component.html
+++ b/src/themes/mdsoar-hood/app/footer/footer.component.html
@@ -13,10 +13,7 @@
             <a href="http://www.hood.edu">www.hood.edu</a>
           </p>
           <hr>
-          <p>
-                                If you wish to submit a copyright complaint or withdrawal request, please email
-                                <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-          </p>
+          <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
         </div>
       </div>
     </div>

--- a/src/themes/mdsoar-hood/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-hood/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-loyola-notre-dame/app/footer/footer.component.html
+++ b/src/themes/mdsoar-loyola-notre-dame/app/footer/footer.component.html
@@ -11,10 +11,7 @@
                                   Baltimore, MD 21212
           </p>
           <hr>
-          <p>
-                                  If you wish to submit a copyright complaint or withdrawal request, please email
-                                  <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-          </p>
+          <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
         </div>
       </div>
     </div>

--- a/src/themes/mdsoar-loyola-notre-dame/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-loyola-notre-dame/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-morgan/app/footer/footer.component.html
+++ b/src/themes/mdsoar-morgan/app/footer/footer.component.html
@@ -10,10 +10,7 @@
             <br>
           </p>
           <hr>
-          <p>
-                                  If you wish to submit a copyright complaint or withdrawal request, please email
-                                  <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-          </p>
+          <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
         </div>
       </div>
     </div>

--- a/src/themes/mdsoar-morgan/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-morgan/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-salisbury/app/footer/footer.component.html
+++ b/src/themes/mdsoar-salisbury/app/footer/footer.component.html
@@ -20,10 +20,7 @@
                                   Phone: <a href="tel:4105436206">410.543.6206</a>
           </p>
           <hr>
-          <p>
-                                  If you wish to submit a copyright complaint or withdrawal request, please email
-                                  <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-          </p>
+          <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
         </div>
       </div>
     </div>

--- a/src/themes/mdsoar-salisbury/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-salisbury/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-st-marys/app/footer/footer.component.html
+++ b/src/themes/mdsoar-st-marys/app/footer/footer.component.html
@@ -19,10 +19,7 @@
             <br>
           </p>
           <hr>
-          <p>
-                                  If you wish to submit a copyright complaint or withdrawal request, please email
-                                  <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-          </p>
+          <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
         </div>
       </div>
     </div>

--- a/src/themes/mdsoar-st-marys/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-st-marys/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-stevenson/app/footer/footer.component.html
+++ b/src/themes/mdsoar-stevenson/app/footer/footer.component.html
@@ -22,10 +22,7 @@
             <br>
           </p>
           <hr>
-          <p>
-                                  If you wish to submit a copyright complaint or withdrawal request, please email
-                                  <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-          </p>
+          <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
         </div>
       </div>
     </div>

--- a/src/themes/mdsoar-stevenson/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-stevenson/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-towson/app/footer/footer.component.html
+++ b/src/themes/mdsoar-towson/app/footer/footer.component.html
@@ -23,10 +23,7 @@
             <br>
           </p>
           <hr>
-          <p>
-                                  If you wish to submit a copyright complaint or withdrawal request, please email
-                                  <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-          </p>
+          <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
         </div>
       </div>
     </div>

--- a/src/themes/mdsoar-towson/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-towson/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-ubalt/app/footer/footer.component.html
+++ b/src/themes/mdsoar-ubalt/app/footer/footer.component.html
@@ -13,10 +13,7 @@
                                   Email: <a href="mailto:knowledgeworks@ubalt.edu">knowledgeworks&#64;ubalt.edu</a>
           </p>
           <hr>
-          <p>
-                                  If you wish to submit a copyright complaint or withdrawal request, please email
-                                  <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-          </p>
+          <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
         </div>
       </div>
     </div>

--- a/src/themes/mdsoar-ubalt/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-ubalt/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-umbc/app/footer/footer.component.html
+++ b/src/themes/mdsoar-umbc/app/footer/footer.component.html
@@ -21,10 +21,7 @@
             <br>
           </p>
           <hr>
-          <p>
-                                  If you wish to submit a copyright complaint or withdrawal request, please email
-                                  <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-          </p>
+          <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
         </div>
       </div>
     </div>

--- a/src/themes/mdsoar-umbc/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-umbc/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar-umes/app/footer/footer.component.html
+++ b/src/themes/mdsoar-umes/app/footer/footer.component.html
@@ -14,10 +14,7 @@
                                     Phone: <a href="tel:4106516270">410-651-6270</a>
     </p>
     <hr>
-    <p>
-                                    If you wish to submit a copyright complaint or withdrawal request, please email
-                                    <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&amp;body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
-                                </p>
+    <ds-umd-footer-accessibility></ds-umd-footer-accessibility>
     </div>
     </div>
     </div>

--- a/src/themes/mdsoar-umes/app/footer/footer.component.ts
+++ b/src/themes/mdsoar-umes/app/footer/footer.component.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 
 import { FooterComponent as BaseComponent } from '../../../mdsoar/app/footer/footer.component';
+import { UmdFooterAccessibilityComponent } from '../../../mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component';
 
 @Component({
   selector: 'ds-themed-footer',
   styleUrls: ['../../../mdsoar/app/footer/footer.component.scss'],
   templateUrl: 'footer.component.html',
-  imports: [],
+  imports: [UmdFooterAccessibilityComponent],
   standalone: true,
 })
 export class FooterComponent extends BaseComponent {

--- a/src/themes/mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component.html
+++ b/src/themes/mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component.html
@@ -1,0 +1,12 @@
+<p>
+  If you wish to submit a copyright complaint or withdrawal request, please email
+  <a href="mailto:mdsoar-help@umd.edu?subject=Takedown%20Request&body=In%20your%20request,%20please%20include%20a%20link%20to%20the%20resource">mdsoar-help&#64;umd.edu</a>.
+</p>
+
+<p>
+  For MD-SOAR accessibility information, please visit our
+  <a [routerLink]="'/info/mdsoar-accessibility'">accessibility page</a>. For
+  information on requesting a remediated copy of a record, please
+  review
+  <a [routerLink]="'/info/mdsoar-accessibility'" fragment="requesting-record-remediation">steps for requesting remediation</a>.
+</p>

--- a/src/themes/mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component.spec.ts
+++ b/src/themes/mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component.spec.ts
@@ -1,0 +1,35 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { ActivatedRouteStub } from 'src/app/shared/testing/active-router.stub';
+
+import { UmdFooterAccessibilityComponent } from './umd-footer-accessibility.component';
+
+describe('UmdFooterAccessibilityComponent', () => {
+  let component: UmdFooterAccessibilityComponent;
+  let fixture: ComponentFixture<UmdFooterAccessibilityComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [UmdFooterAccessibilityComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UmdFooterAccessibilityComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/themes/mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component.ts
+++ b/src/themes/mdsoar/app/umd-footer-accessibility/umd-footer-accessibility.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'ds-umd-footer-accessibility',
+  styleUrls: ['umd-footer-accessibility.component.scss'],
+  templateUrl: 'umd-footer-accessibility.component.html',
+  imports: [RouterLink],
+  standalone: true,
+})
+export class UmdFooterAccessibilityComponent {
+}


### PR DESCRIPTION
Added a "umd-footer-accessibility" component to the "mdsoar" theme as a common component for providing accessibility information in each of the footers in the institutional themes.

Also moved the information about submitted a copyright complaint or withdrawal request into the component, to reduce duplication in the institutional footers.

Updated the institutional footers to use the new component.

https://umd-dit.atlassian.net/browse/LIBCIR-479
